### PR TITLE
App-aware context, dual-instance fix, gitignore credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+leanring-buddy/DirectAPICredentials.swift
 worker/node_modules/
 worker/.dev.vars
 .DS_Store

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -625,11 +625,21 @@ final class CompanionManager: ObservableObject {
                     (userPlaceholder: entry.userTranscript, assistantResponse: entry.assistantResponse)
                 }
 
+                // Capture which app the user is currently working in so Claude
+                // can give more targeted help without needing to infer it from the screenshot.
+                let frontmostAppName = NSWorkspace.shared.frontmostApplication?.localizedName
+                let userPromptWithAppContext: String = {
+                    if let appName = frontmostAppName {
+                        return "[User is currently in \(appName)]\n\(transcript)"
+                    }
+                    return transcript
+                }()
+
                 let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
                     images: labeledImages,
                     systemPrompt: Self.companionVoiceResponseSystemPrompt,
                     conversationHistory: historyForAPI,
-                    userPrompt: transcript,
+                    userPrompt: userPromptWithAppContext,
                     onTextChunk: { _ in
                         // No streaming text display — spinner stays until TTS plays
                     }

--- a/leanring-buddy/DirectAPICredentials.swift.example
+++ b/leanring-buddy/DirectAPICredentials.swift.example
@@ -2,8 +2,8 @@
 //  DirectAPICredentials.swift
 //  leanring-buddy
 //
-//  Add your own API keys here. These are read directly by the app
-//  without needing the Cloudflare Worker proxy.
+//  Copy this file to DirectAPICredentials.swift and fill in your keys.
+//  DirectAPICredentials.swift is gitignored — your keys will never be committed.
 //  Claude calls go through the Claude Code CLI (see ClaudeCodeCLIClient.swift).
 //
 

--- a/leanring-buddy/leanring_buddyApp.swift
+++ b/leanring-buddy/leanring_buddyApp.swift
@@ -81,12 +81,19 @@ final class CompanionAppDelegate: NSObject, NSApplicationDelegate {
     /// that when a developer hits Cmd+R in Xcode, the fresh build takes
     /// over instead of being silently ignored in favor of the stale login
     /// item copy.
+    /// All known Clicky bundle identifiers — catches both the Xcode dev build
+    /// and FarzaTV's packaged release so neither can run alongside ours.
+    private static let allClickyBundleIdentifiers = [
+        "com.yourcompany.leanring-buddy",
+        "com.humansongs.clicky",
+    ]
+
     private func terminateOtherRunningInstancesOfClicky() {
         guard let ownBundleIdentifier = Bundle.main.bundleIdentifier else { return }
         let ownProcessIdentifier = ProcessInfo.processInfo.processIdentifier
 
-        let otherInstancesOfClicky = NSRunningApplication
-            .runningApplications(withBundleIdentifier: ownBundleIdentifier)
+        let otherInstancesOfClicky = Self.allClickyBundleIdentifiers
+            .flatMap { bundleID in NSRunningApplication.runningApplications(withBundleIdentifier: bundleID) }
             .filter { runningApplication in
                 runningApplication.processIdentifier != ownProcessIdentifier
             }
@@ -111,8 +118,8 @@ final class CompanionAppDelegate: NSObject, NSApplicationDelegate {
         // and the first push-to-talk after launch still double-fires.
         let maxWaitUntilOthersExit = Date().addingTimeInterval(1.5)
         while Date() < maxWaitUntilOthersExit {
-            let stillRunning = NSRunningApplication
-                .runningApplications(withBundleIdentifier: ownBundleIdentifier)
+            let stillRunning = Self.allClickyBundleIdentifiers
+                .flatMap { bundleID in NSRunningApplication.runningApplications(withBundleIdentifier: bundleID) }
                 .contains { runningApplication in
                     runningApplication.processIdentifier != ownProcessIdentifier
                 }
@@ -123,8 +130,8 @@ final class CompanionAppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Force-kill any stragglers that still haven't exited.
-        let stragglers = NSRunningApplication
-            .runningApplications(withBundleIdentifier: ownBundleIdentifier)
+        let stragglers = Self.allClickyBundleIdentifiers
+            .flatMap { bundleID in NSRunningApplication.runningApplications(withBundleIdentifier: bundleID) }
             .filter { runningApplication in
                 runningApplication.processIdentifier != ownProcessIdentifier
             }


### PR DESCRIPTION
## Summary

- **App-aware context**: Clicky now prepends the frontmost app name to every Claude prompt (e.g. `[User is currently in Xcode]`). Claude can give targeted help without needing to infer the app from the screenshot.
- **Dual-instance fix**: The startup duplicate-detection now catches both the Xcode dev build (`com.yourcompany.leanring-buddy`) and the packaged release (`com.humansongs.clicky`), so both can't run simultaneously and cause double TTS responses.
- **Credentials safety**: `DirectAPICredentials.swift` is gitignored and renamed to `.example` in the repo. Real API keys stay local only. New contributors copy the `.example` file and fill in their own keys.

## Test plan

- [ ] Build and run — verify only one Clicky instance is active
- [ ] Press Ctrl+Option and ask a question — Claude's response references the correct app
- [ ] Confirm `DirectAPICredentials.swift` does not appear in `git status` after filling in keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)