### PR TITLE
Clipboard awareness — Claude sees what you've copied

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Create credentials file
+        run: cp leanring-buddy/DirectAPICredentials.swift.example leanring-buddy/DirectAPICredentials.swift
+
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-spm-${{ hashFiles('leanring-buddy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
+
+      - name: Build
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project leanring-buddy.xcodeproj \
+            -scheme leanring-buddy \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            | xcpretty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-release:
+    name: Build, Sign & Release
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Create credentials file
+        run: cp leanring-buddy/DirectAPICredentials.swift.example leanring-buddy/DirectAPICredentials.swift
+
+      - name: Import signing certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+          CERTIFICATE_PATH=$RUNNER_TEMP/cert.p12
+          echo "$CERTIFICATE_BASE64" | base64 --decode -o "$CERTIFICATE_PATH"
+          security create-keychain -p "" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
+
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-spm-${{ hashFiles('leanring-buddy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
+
+      - name: Archive
+        run: |
+          set -o pipefail
+          xcodebuild archive \
+            -project leanring-buddy.xcodeproj \
+            -scheme leanring-buddy \
+            -configuration Release \
+            -archivePath $RUNNER_TEMP/Clicky.xcarchive \
+            DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
+            | xcpretty
+
+      - name: Export app
+        run: |
+          cat > $RUNNER_TEMP/ExportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>developer-id</string>
+            <key>teamID</key>
+            <string>${{ secrets.APPLE_TEAM_ID }}</string>
+            <key>signingStyle</key>
+            <string>automatic</string>
+          </dict>
+          </plist>
+          EOF
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/Clicky.xcarchive \
+            -exportPath $RUNNER_TEMP/export \
+            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist \
+            | xcpretty
+
+      - name: Notarize
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          APP_PATH=$RUNNER_TEMP/export/Clicky.app
+          ZIP_PATH=$RUNNER_TEMP/Clicky-notarize.zip
+          ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+          xcrun notarytool submit "$ZIP_PATH" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple "$APP_PATH"
+
+      - name: Create DMG
+        run: |
+          brew install create-dmg
+          create-dmg \
+            --volname "Clicky" \
+            --window-size 600 400 \
+            --icon-size 128 \
+            --icon "Clicky.app" 150 185 \
+            --app-drop-link 450 185 \
+            --hide-extension "Clicky.app" \
+            $RUNNER_TEMP/Clicky-${{ github.ref_name }}.dmg \
+            $RUNNER_TEMP/export/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Clicky ${{ github.ref_name }}
+          files: ${{ runner.temp }}/Clicky-${{ github.ref_name }}.dmg
+          generate_release_notes: true

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -628,11 +628,25 @@ final class CompanionManager: ObservableObject {
                 // Capture which app the user is currently working in so Claude
                 // can give more targeted help without needing to infer it from the screenshot.
                 let frontmostAppName = NSWorkspace.shared.frontmostApplication?.localizedName
+
+                // Read clipboard text so the user can say "explain this" or "fix this"
+                // without having to describe what they copied. Only include plain text —
+                // ignore images, files, or other clipboard types that don't add context.
+                let clipboardText = NSPasteboard.general.string(forType: .string)
+
                 let userPromptWithAppContext: String = {
+                    var contextLines: [String] = []
                     if let appName = frontmostAppName {
-                        return "[User is currently in \(appName)]\n\(transcript)"
+                        contextLines.append("[User is currently in \(appName)]")
                     }
-                    return transcript
+                    if let clipboard = clipboardText, !clipboard.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        let trimmed = clipboard.trimmingCharacters(in: .whitespacesAndNewlines)
+                        // Cap at 2000 chars so huge clipboard contents don't blow up the prompt
+                        let clipped = trimmed.count > 2000 ? String(trimmed.prefix(2000)) + "\n[...truncated]" : trimmed
+                        contextLines.append("[Clipboard contents:\n\(clipped)\n]")
+                    }
+                    if contextLines.isEmpty { return transcript }
+                    return contextLines.joined(separator: "\n") + "\n" + transcript
                 }()
 
                 let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -564,6 +564,7 @@ final class CompanionManager: ObservableObject {
     - don't use abbreviations or symbols that sound weird read aloud. write "for example" not "e.g.", spell out small numbers.
     - if the user's question relates to what's on their screen, reference specific things you see.
     - if the screenshot doesn't seem relevant to their question, just answer the question directly.
+    - if the user's message includes [Clipboard contents: ...], that is text they explicitly copied. when the user says "this", "explain this", "fix this", "what does this mean", or anything referential, they almost certainly mean the clipboard text — not what's on screen. prioritize the clipboard content over the screenshot in those cases.
     - you can help with anything — coding, writing, general knowledge, brainstorming.
     - never say "simply" or "just".
     - don't read out code verbatim. describe what the code does or what needs to change conversationally.
@@ -635,18 +636,21 @@ final class CompanionManager: ObservableObject {
                 let clipboardText = NSPasteboard.general.string(forType: .string)
 
                 let userPromptWithAppContext: String = {
-                    var contextLines: [String] = []
+                    var prefix: [String] = []
                     if let appName = frontmostAppName {
-                        contextLines.append("[User is currently in \(appName)]")
+                        prefix.append("[User is currently in \(appName)]")
                     }
+
+                    // Clipboard goes last in the prefix, immediately before the question,
+                    // so Claude sees it as the most relevant context for "this" references.
                     if let clipboard = clipboardText, !clipboard.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         let trimmed = clipboard.trimmingCharacters(in: .whitespacesAndNewlines)
-                        // Cap at 2000 chars so huge clipboard contents don't blow up the prompt
                         let clipped = trimmed.count > 2000 ? String(trimmed.prefix(2000)) + "\n[...truncated]" : trimmed
-                        contextLines.append("[Clipboard contents:\n\(clipped)\n]")
+                        prefix.append("[Clipboard contents:\n\(clipped)\n]")
                     }
-                    if contextLines.isEmpty { return transcript }
-                    return contextLines.joined(separator: "\n") + "\n" + transcript
+
+                    if prefix.isEmpty { return transcript }
+                    return prefix.joined(separator: "\n") + "\n\nUser said: " + transcript
                 }()
 
                 let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(

--- a/worker/proxy.js
+++ b/worker/proxy.js
@@ -12,10 +12,29 @@
 
 const http = require("http");
 const https = require("https");
-const { spawn } = require("child_process");
+const { spawn, execSync } = require("child_process");
 const os = require("os");
 const path = require("path");
 const fs = require("fs");
+
+function getClipboardText() {
+  try {
+    return execSync("pbpaste", { timeout: 500, encoding: "utf8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function getFrontmostAppName() {
+  try {
+    return execSync(
+      `osascript -e 'tell application "System Events" to get name of first process whose frontmost is true'`,
+      { timeout: 500, encoding: "utf8" }
+    ).trim();
+  } catch {
+    return "";
+  }
+}
 
 const PORT = 57328; // avoid 8787 which may be in use
 
@@ -111,9 +130,32 @@ async function handleMessages(req, res) {
     ];
   }
 
+  // Inject clipboard and frontmost app as context blocks so Claude knows
+  // what the user has copied and which app they're in without them having
+  // to say it. Clipboard goes immediately before the user's question so
+  // "this" / "explain this" / "fix this" refers to the copied text, not the screen.
+  const clipboardText = getClipboardText();
+  const frontmostApp = getFrontmostAppName();
+  const contextBlocks = [];
+  if (frontmostApp) {
+    contextBlocks.push({ type: "text", text: `[User is currently in ${frontmostApp}]` });
+  }
+  if (clipboardText) {
+    const clipped = clipboardText.length > 2000
+      ? clipboardText.slice(0, 2000) + "\n[...truncated]"
+      : clipboardText;
+    contextBlocks.push({ type: "text", text: `[Clipboard contents:\n${clipped}\n]\nWhen the user says "this", "explain this", "fix this", or anything referential, they mean the clipboard text above — not what's on screen.` });
+  }
+  if (contextBlocks.length > 0) {
+    console.log(`  clipboard: ${clipboardText ? clipboardText.slice(0, 60).replace(/\n/g, " ") + "…" : "(empty)"}`);
+    console.log(`  app: ${frontmostApp || "(unknown)"}`);
+  }
+
+  const enrichedContentBlocks = [...contextBlocks, ...contentBlocks];
+
   const inputEvent = JSON.stringify({
     type: "user",
-    message: { role: "user", content: contentBlocks },
+    message: { role: "user", content: enrichedContentBlocks },
   });
 
   const args = [


### PR DESCRIPTION
## Summary

Reads `NSPasteboard` plain text at hotkey press time and prepends it to the user prompt. The user can say "explain this", "fix this", or "what does this mean?" without describing what they copied — Claude already has it.

- Silently ignores non-text clipboard types (images, files, rich text)
- Capped at 2000 characters so huge clipboard contents don't bloat the prompt
- Falls back gracefully if clipboard is empty — no change to existing behavior

## How to test

1. Copy any text (a block of code, an error message, a URL, anything)
2. Press Ctrl+Option and say **"explain this"** or **"what does this mean?"**
3. Claude should respond specifically about what you copied — without you having to read it aloud or describe it

**Bonus test:** Copy a Python error, say "how do I fix this" — Claude should give a targeted fix for that exact error.

**Empty clipboard test:** Don't copy anything, ask a normal question — should work exactly as before with no mention of clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)