### PR TITLE
Integrate approved Codex session lifecycle fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ coding-plans/
 hermes-agent-capability-report.html
 leanring-buddy.xcodeproj/xcuserdata/
 worker/.wrangler/
+.worktrees/
+worker/intercept.crt
+worker/intercept.key
+worker/intercept.js
+worker/setup-intercept.sh
+worker/start-intercept.sh
+worker/teardown-intercept.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 macOS menu bar companion app. Lives entirely in the macOS status bar (no dock icon, no main window). Clicking the menu bar icon opens a custom floating panel with companion voice controls. Uses push-to-talk (ctrl+option) to capture voice input, transcribes it via AssemblyAI streaming, and sends the transcript + a screenshot of the user's screen to Claude. Claude responds with text (streamed via SSE) and voice (ElevenLabs TTS). A blue cursor overlay can fly to and point at UI elements Claude references on any connected monitor.
 
-All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in the app.
+API keys should live on a Cloudflare Worker proxy or local development-only credentials — nothing sensitive ships in the app.
 
 ## Architecture
 
@@ -61,12 +61,12 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | `CompanionScreenCaptureUtility.swift` | ~132 | Multi-monitor screenshot capture using ScreenCaptureKit. Returns labeled image data for each connected display. |
 | `BuddyDictationManager.swift` | ~866 | Push-to-talk voice pipeline. Handles microphone capture via `AVAudioEngine`, provider-aware permission checks, keyboard/button dictation sessions, transcript finalization, shortcut parsing, contextual keyterms, and live audio-level reporting for waveform feedback. |
 | `BuddyTranscriptionProvider.swift` | ~100 | Protocol surface and provider factory for voice transcription backends. Resolves provider based on `VoiceTranscriptionProvider` in Info.plist — AssemblyAI, OpenAI, or Apple Speech. |
-| `AssemblyAIStreamingTranscriptionProvider.swift` | ~478 | Streaming transcription provider. Fetches temp tokens from the Cloudflare Worker, opens an AssemblyAI v3 websocket, streams PCM16 audio, tracks turn-based transcripts, and delivers finalized text on key-up. Shares a single URLSession across all sessions. |
+| `AssemblyAIStreamingTranscriptionProvider.swift` | ~550 | Streaming transcription provider. Fetches temp tokens from a configured proxy or direct AssemblyAI API key, opens an AssemblyAI v3 websocket, streams PCM16 audio, tracks turn-based transcripts, and delivers finalized text on key-up. Shares a single URLSession across all sessions. |
 | `OpenAIAudioTranscriptionProvider.swift` | ~317 | Upload-based transcription provider. Buffers push-to-talk audio locally, uploads as WAV on release, returns finalized transcript. |
 | `AppleSpeechTranscriptionProvider.swift` | ~147 | Local fallback transcription provider backed by Apple's Speech framework. |
 | `BuddyAudioConversionSupport.swift` | ~108 | Audio conversion helpers. Converts live mic buffers to PCM16 mono audio and builds WAV payloads for upload-based providers. |
 | `GlobalPushToTalkShortcutMonitor.swift` | ~132 | System-wide push-to-talk monitor. Owns the listen-only `CGEvent` tap and publishes press/release transitions. |
-| `ClaudeAPI.swift` | ~320 | Claude vision API client with streaming (SSE) and non-streaming modes. Supports two auth modes: `proxyURL` (Cloudflare Worker) and `claudeCodeOAuth` (direct Anthropic API using Claude Code Keychain token). TLS warmup optimization, image MIME detection, conversation history support. |
+| `ClaudeAPI.swift` | ~320 | Claude vision API client with streaming (SSE) and non-streaming modes. Supports configured `proxyURL` and `claudeCodeOAuth` auth modes. TLS warmup optimization, image MIME detection, conversation history support. |
 | `ClaudeCodeOAuthProvider.swift` | ~70 | Reads the Claude Code OAuth bearer token from the macOS Keychain ("Claude Code-credentials"). Used by CompanionManager to bypass the Cloudflare Worker for Claude calls when the user has Claude Code installed. |
 | `OpenAIAPI.swift` | ~142 | OpenAI GPT vision API client. |
 | `ElevenLabsTTSClient.swift` | ~81 | ElevenLabs TTS client. Sends text to the Worker proxy, plays back audio via `AVAudioPlayer`. Exposes `isPlaying` for transient cursor scheduling. |
@@ -76,10 +76,12 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | `WindowPositionManager.swift` | ~262 | Window placement logic, Screen Recording permission flow, and accessibility permission helpers. |
 | `AppBundleConfiguration.swift` | ~28 | Runtime configuration reader for keys stored in the app bundle Info.plist. |
 | `MemoryManager.swift` | ~291 | Persistent memory across sessions. Writes facts to `~/.clicky/memory.md` + `user.md`, persists last 20 exchanges to `history.json`. Background Claude extraction after each turn via ClaudeCodeCLIClient. |
-| `AgentSession.swift` | ~40 | Data model for a single Codex agent task. Holds task description, triangle color (from a 6-color palette), status (running/completed/failed), and result. |
-| `AgentSessionManager.swift` | ~70 | Manages multiple concurrent Codex agent sessions (the "siblings"). Cycles through triangle colors, runs each agent in a background Task, publishes session state changes, auto-removes completed sessions after 8s. |
-| `AgentSiblingsOverlayWindow.swift` | ~180 | Floating NSPanel showing "mini clicky siblings" — one dark rounded square icon per agent, with colored triangle + status dot. Non-activating, stays on all Spaces. Shows/hides based on active sessions. |
-| `CodexCLIClient.swift` | ~239 | Codex CLI client for agent tasks. Primary trigger phrase: "clicky agent". Runs `codex exec --json` subprocess, parses JSONL events. Uses `~/.local/bin/codex-clicky` (v0.124.0). |
+| `AgentSession.swift` | ~50 | Data model for a single Codex agent task. Holds task description, triangle color (from a 6-color palette), status (running/completed/failed), result, live output, and Codex thread ID. |
+| `AgentSessionManager.swift` | ~300 | Manages multiple concurrent Codex agent sessions (the "siblings") on the shared `codex app-server`. Publishes live output, supports follow-ups, interrupts running turns, archives closed threads, and keeps completed sessions inspectable before cleanup. |
+| `AgentSiblingsOverlayWindow.swift` | ~250 | Floating NSPanel showing "mini clicky siblings" — one dark rounded square icon per agent, with colored triangle + status dot. Non-activating, stays on all Spaces. Click opens session details; long-press dismisses/stops a session. |
+| `AgentSessionDetailWindow.swift` | ~260 | Click-to-inspect floating panel for a Codex sibling. Shows task status, live streamed output, and follow-up composer. |
+| `CodexAppServerClient.swift` | ~600 | Long-lived JSON-RPC client for `codex app-server`. Starts threads, streams events, interrupts turns, archives threads, and kills the server process tree on app exit or parent-process disappearance. |
+| `CodexCLIClient.swift` | ~760 | Legacy/fallback Codex CLI client and transcript classifier for agent tasks. Parses JSONL, captures stderr, closes stdin to avoid hangs, supports parallel task decomposition and follow-up execution. |
 | `worker/src/index.ts` | ~142 | Cloudflare Worker proxy. Three routes: `/chat` (Claude), `/tts` (ElevenLabs), `/transcribe-token` (AssemblyAI temp token). |
 
 ## Build & Run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,11 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | `ClickyAnalytics.swift` | ~121 | PostHog analytics integration for usage tracking. |
 | `WindowPositionManager.swift` | ~262 | Window placement logic, Screen Recording permission flow, and accessibility permission helpers. |
 | `AppBundleConfiguration.swift` | ~28 | Runtime configuration reader for keys stored in the app bundle Info.plist. |
+| `MemoryManager.swift` | ~291 | Persistent memory across sessions. Writes facts to `~/.clicky/memory.md` + `user.md`, persists last 20 exchanges to `history.json`. Background Claude extraction after each turn via ClaudeCodeCLIClient. |
+| `AgentSession.swift` | ~40 | Data model for a single Codex agent task. Holds task description, triangle color (from a 6-color palette), status (running/completed/failed), and result. |
+| `AgentSessionManager.swift` | ~70 | Manages multiple concurrent Codex agent sessions (the "siblings"). Cycles through triangle colors, runs each agent in a background Task, publishes session state changes, auto-removes completed sessions after 8s. |
+| `AgentSiblingsOverlayWindow.swift` | ~180 | Floating NSPanel showing "mini clicky siblings" — one dark rounded square icon per agent, with colored triangle + status dot. Non-activating, stays on all Spaces. Shows/hides based on active sessions. |
+| `CodexCLIClient.swift` | ~239 | Codex CLI client for agent tasks. Primary trigger phrase: "clicky agent". Runs `codex exec --json` subprocess, parses JSONL events. Uses `~/.local/bin/codex-clicky` (v0.124.0). |
 | `worker/src/index.ts` | ~142 | Cloudflare Worker proxy. Three routes: `/chat` (Claude), `/tts` (ElevenLabs), `/transcribe-token` (AssemblyAI temp token). |
 
 ## Build & Run

--- a/leanring-buddy/AgentSession.swift
+++ b/leanring-buddy/AgentSession.swift
@@ -1,0 +1,45 @@
+//
+//  AgentSession.swift
+//  leanring-buddy
+//
+//  Data model for a single running or completed Codex agent task.
+//  AgentSessionManager owns a published array of these and the
+//  AgentSiblingsOverlay renders them as "mini clicky siblings".
+//
+
+import Foundation
+import SwiftUI
+
+enum AgentSessionStatus {
+    case running
+    case completed
+    case failed
+}
+
+struct AgentSession: Identifiable {
+    let id: UUID
+    let taskDescription: String
+    let triangleColor: Color
+    var status: AgentSessionStatus
+    var result: String?
+    let startedAt: Date
+
+    // Cycles through these colors as new agents are spawned so each sibling
+    // is visually distinct at a glance.
+    static let palette: [Color] = [
+        Color(hex: "#F5C518"), // yellow
+        Color(hex: "#E74C3C"), // red
+        Color(hex: "#3B82F6"), // blue
+        Color(hex: "#22C55E"), // green
+        Color(hex: "#A855F7"), // purple
+        Color(hex: "#F97316"), // orange
+    ]
+
+    init(taskDescription: String, triangleColor: Color) {
+        self.id = UUID()
+        self.taskDescription = taskDescription
+        self.triangleColor = triangleColor
+        self.status = .running
+        self.startedAt = Date()
+    }
+}

--- a/leanring-buddy/AgentSession.swift
+++ b/leanring-buddy/AgentSession.swift
@@ -22,6 +22,13 @@ struct AgentSession: Identifiable {
     let triangleColor: Color
     var status: AgentSessionStatus
     var result: String?
+    /// Live streaming output from Codex while the agent runs. Updated as
+    /// codex emits text deltas. Shown in the detail panel when the user
+    /// clicks the sibling icon.
+    var liveOutput: String
+    /// Codex thread ID captured from the `thread.started` event. Required
+    /// so the user can send follow-up messages via `codex exec resume`.
+    var codexThreadID: String?
     let startedAt: Date
 
     // Cycles through these colors as new agents are spawned so each sibling
@@ -40,6 +47,8 @@ struct AgentSession: Identifiable {
         self.taskDescription = taskDescription
         self.triangleColor = triangleColor
         self.status = .running
+        self.liveOutput = ""
+        self.codexThreadID = nil
         self.startedAt = Date()
     }
 }

--- a/leanring-buddy/AgentSessionDetailWindow.swift
+++ b/leanring-buddy/AgentSessionDetailWindow.swift
@@ -1,0 +1,361 @@
+//
+//  AgentSessionDetailWindow.swift
+//  leanring-buddy
+//
+//  Click-to-inspect floating panel that opens when the user taps a sibling
+//  icon. Shows the full task description, status badge ("Running" / "Done" /
+//  "Failed"), elapsed time, and the live streaming output that Codex emits
+//  as the agent runs. The panel re-renders automatically whenever the
+//  session it's bound to publishes a state change.
+//
+
+import AppKit
+import SwiftUI
+
+// MARK: - Window manager
+
+@MainActor
+final class AgentSessionDetailWindowManager {
+    private var window: AgentSessionDetailWindow?
+    private var dismissOutsideClickMonitor: Any?
+    private var displayedSessionID: UUID?
+    /// Closure injected by CompanionManager to send a follow-up prompt to a
+    /// specific session via the codex resume flow.
+    var onSendFollowUp: ((UUID, String) -> Void)?
+
+    /// Shows (or moves) the detail panel anchored to the given icon frame.
+    /// `iconScreenFrame` is the icon's frame in screen coordinates; the panel
+    /// is placed to its left with a small gap so it doesn't cover the icon.
+    func show(
+        sessionID: UUID,
+        sessionManager: AgentSessionManager,
+        anchoredTo iconScreenFrame: NSRect
+    ) {
+        if window == nil {
+            window = AgentSessionDetailWindow(
+                sessionID: sessionID,
+                sessionManager: sessionManager,
+                onClose: { [weak self] in self?.hide() },
+                onSendFollowUp: { [weak self] sid, prompt in
+                    self?.onSendFollowUp?(sid, prompt)
+                }
+            )
+        } else {
+            window?.update(
+                sessionID: sessionID,
+                sessionManager: sessionManager,
+                onClose: { [weak self] in self?.hide() }
+            )
+        }
+        displayedSessionID = sessionID
+
+        guard let panel = window else { return }
+
+        let panelWidth: CGFloat = 360
+        let panelHeight: CGFloat = 320
+        // Anchor to the LEFT of the icon with a small gap, vertically aligned
+        // to the icon's vertical midpoint.
+        let gap: CGFloat = 12
+        let panelX = iconScreenFrame.minX - panelWidth - gap
+        let panelY = iconScreenFrame.midY - panelHeight / 2
+        panel.setFrame(NSRect(x: panelX, y: panelY, width: panelWidth, height: panelHeight), display: true)
+        panel.orderFront(nil)
+
+        installOutsideClickMonitor()
+    }
+
+    func hide() {
+        window?.orderOut(nil)
+        displayedSessionID = nil
+        if let monitor = dismissOutsideClickMonitor {
+            NSEvent.removeMonitor(monitor)
+            dismissOutsideClickMonitor = nil
+        }
+    }
+
+    private func installOutsideClickMonitor() {
+        if dismissOutsideClickMonitor != nil { return }
+        dismissOutsideClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
+            // Any click outside the panel hides it. The panel itself swallows
+            // clicks before they reach the global monitor.
+            DispatchQueue.main.async { self?.hide() }
+        }
+    }
+
+    var isShowing: Bool { window?.isVisible ?? false }
+    var currentSessionID: UUID? { displayedSessionID }
+}
+
+// MARK: - The NSPanel
+
+final class AgentSessionDetailWindow: NSPanel {
+    private var hostingController: NSHostingController<AgentSessionDetailHostView>?
+    private var onClose: () -> Void
+    private var onSendFollowUp: (UUID, String) -> Void
+
+    init(
+        sessionID: UUID,
+        sessionManager: AgentSessionManager,
+        onClose: @escaping () -> Void,
+        onSendFollowUp: @escaping (UUID, String) -> Void
+    ) {
+        self.onClose = onClose
+        self.onSendFollowUp = onSendFollowUp
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 320),
+            styleMask: [.borderless, .nonactivatingPanel, .titled],
+            backing: .buffered,
+            defer: false
+        )
+        // Need .titled in styleMask so TextField inside accepts text input,
+        // but we hide the title bar for the borderless look.
+        styleMask.remove(.titled)
+        styleMask.insert(.borderless)
+
+        isOpaque = false
+        backgroundColor = .clear
+        level = .floating
+        isReleasedWhenClosed = false
+        hasShadow = true
+        hidesOnDeactivate = false
+        ignoresMouseEvents = false
+        collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+
+        let rootView = AgentSessionDetailHostView(
+            sessionID: sessionID,
+            sessionManager: sessionManager,
+            onClose: onClose,
+            onCloseSession: { [weak self, weak sessionManager] sid in
+                sessionManager?.removeSession(id: sid)
+                self?.onClose()
+            },
+            onSendFollowUp: onSendFollowUp
+        )
+        let hc = NSHostingController(rootView: rootView)
+        hostingController = hc
+        contentView = hc.view
+        contentView?.wantsLayer = true
+        contentView?.layer?.backgroundColor = NSColor.clear.cgColor
+    }
+
+    /// Allow this panel to become key so its TextField can take keyboard
+    /// focus for follow-up text input. Without this, typing into the field
+    /// silently does nothing because focus stays on the previous app.
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+
+    func update(sessionID: UUID, sessionManager: AgentSessionManager, onClose: @escaping () -> Void) {
+        self.onClose = onClose
+        let newRoot = AgentSessionDetailHostView(
+            sessionID: sessionID,
+            sessionManager: sessionManager,
+            onClose: onClose,
+            onCloseSession: { [weak self, weak sessionManager] sid in
+                sessionManager?.removeSession(id: sid)
+                self?.onClose()
+            },
+            onSendFollowUp: onSendFollowUp
+        )
+        hostingController?.rootView = newRoot
+    }
+}
+
+// MARK: - SwiftUI host view (looks up the session each render so updates flow)
+
+struct AgentSessionDetailHostView: View {
+    let sessionID: UUID
+    @ObservedObject var sessionManager: AgentSessionManager
+    let onClose: () -> Void
+    let onCloseSession: (UUID) -> Void
+    let onSendFollowUp: (UUID, String) -> Void
+
+    var body: some View {
+        if let session = sessionManager.sessions.first(where: { $0.id == sessionID }) {
+            AgentSessionDetailView(
+                session: session,
+                onClose: onClose,
+                onCloseSession: { onCloseSession(session.id) },
+                onSendFollowUp: { prompt in onSendFollowUp(session.id, prompt) }
+            )
+        } else {
+            // Session was already removed (cleanup linger expired). Fade away.
+            EmptyView()
+                .onAppear { onClose() }
+        }
+    }
+}
+
+// MARK: - The actual detail card
+
+struct AgentSessionDetailView: View {
+    let session: AgentSession
+    let onClose: () -> Void
+    let onCloseSession: () -> Void
+    let onSendFollowUp: (String) -> Void
+
+    @State private var followUpDraft: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            outputArea
+            followUpComposer
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(hex: "#1C1F1E"))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+                )
+                .shadow(color: .black.opacity(0.6), radius: 16, x: 0, y: 6)
+        )
+        .frame(width: 360, height: 320)
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(session.taskDescription.uppercased())
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Color(hex: "#ECEEED"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Text(elapsedTimeLabel)
+                    .font(.system(size: 10, weight: .regular))
+                    .foregroundColor(Color(hex: "#888B8A"))
+            }
+
+            Spacer(minLength: 8)
+
+            statusBadge
+
+            Button(action: onCloseSession) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(Color(hex: "#888B8A"))
+                    .frame(width: 18, height: 18)
+                    .background(Circle().fill(Color.white.opacity(0.06)))
+            }
+            .buttonStyle(.plain)
+            .help(session.status == .running ? "Stop and close session" : "Close session")
+        }
+    }
+
+    private var statusBadge: some View {
+        let (label, color): (String, Color) = {
+            switch session.status {
+            case .running:   return ("Running", Color(hex: "#22C55E"))
+            case .completed: return ("Done", Color(hex: "#3B82F6"))
+            case .failed:    return ("Failed", Color(hex: "#EF4444"))
+            }
+        }()
+        return HStack(spacing: 6) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(color)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            Capsule().fill(color.opacity(0.15))
+                .overlay(Capsule().stroke(color.opacity(0.4), lineWidth: 0.5))
+        )
+    }
+
+    private var outputAreaContent: some View {
+        let displayText = session.liveOutput.isEmpty ? placeholderText : session.liveOutput
+        return Text(displayText)
+            .font(.system(size: 11, weight: .regular, design: .monospaced))
+            .foregroundColor(Color(hex: "#C4C7C6"))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .textSelection(.enabled)
+            .id("output")
+    }
+
+    private var outputArea: some View {
+        ScrollView {
+            ScrollViewReader { proxy in
+                outputAreaContent
+                    .onChange(of: session.liveOutput) { _ in
+                        withAnimation(.easeOut(duration: 0.15)) {
+                            proxy.scrollTo("output", anchor: .bottom)
+                        }
+                    }
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(hex: "#0F1110"))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.white.opacity(0.06), lineWidth: 0.5)
+        )
+    }
+
+    private var followUpComposer: some View {
+        let canSend = !followUpDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && session.status != .running
+            && session.codexThreadID != nil
+
+        return HStack(spacing: 8) {
+            TextField("Follow up…", text: $followUpDraft)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(Color(hex: "#ECEEED"))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color(hex: "#0F1110"))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+                )
+                .onSubmit { sendIfPossible() }
+
+            Button(action: sendIfPossible) {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(canSend ? Color.white : Color.white.opacity(0.35))
+                    .frame(width: 28, height: 28)
+                    .background(
+                        Circle().fill(canSend ? Color(hex: "#3B82F6") : Color.white.opacity(0.06))
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSend)
+        }
+    }
+
+    private func sendIfPossible() {
+        let trimmed = followUpDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              session.status != .running,
+              session.codexThreadID != nil else { return }
+        onSendFollowUp(trimmed)
+        followUpDraft = ""
+    }
+
+    private var elapsedTimeLabel: String {
+        let elapsed = Int(Date().timeIntervalSince(session.startedAt))
+        if elapsed < 60 { return "\(elapsed)s elapsed" }
+        let minutes = elapsed / 60
+        let seconds = elapsed % 60
+        return "\(minutes)m \(seconds)s elapsed"
+    }
+
+    private var placeholderText: String {
+        switch session.status {
+        case .running:   return "Waiting for first output…"
+        case .completed: return session.result ?? "(no output)"
+        case .failed:    return session.result ?? "(failed with no output)"
+        }
+    }
+}

--- a/leanring-buddy/AgentSessionManager.swift
+++ b/leanring-buddy/AgentSessionManager.swift
@@ -3,11 +3,13 @@
 //  leanring-buddy
 //
 //  Manages multiple concurrent Codex agent sessions — the "siblings".
-//  Each call to launchAgent() spawns a new background Task that runs
-//  Codex independently, so several agents can work simultaneously
-//  without blocking each other or the voice UI.
+//  Each call to launchAgent() opens a new thread on the long-lived
+//  `codex app-server` process, so several agents can work simultaneously
+//  without blocking each other or the voice UI. (Used to spawn one
+//  `codex exec` subprocess per task — replaced with thread-on-server.)
 //
 
+import Combine
 import Foundation
 import SwiftUI
 
@@ -17,13 +19,21 @@ final class AgentSessionManager: ObservableObject {
 
     private var colorCycleIndex = 0
 
-    // How long a completed/failed session lingers before being removed from the list.
-    private static let completedSessionLingerSeconds: Double = 8
+    // How long a completed/failed session lingers before being removed from
+    // the list. Long enough for the user to inspect the agent's work and
+    // send follow-up messages without the icon disappearing on them.
+    // Long-press the icon to dismiss earlier.
+    private static let completedSessionLingerSeconds: Double = 600
+
+    private static let workspaceRoot = "\(NSHomeDirectory())/Desktop/clicky-agents"
 
     // MARK: - Launch
 
     /// Spawns a new agent for the given prompt and returns immediately.
-    /// The agent runs in the background; onComplete is called (on MainActor) when it finishes.
+    /// The agent runs on its own thread inside the shared codex app-server;
+    /// `onComplete` is called (on MainActor) when it finishes.
+    /// `codexClient` is no longer used (kept for source-compat with callers
+    /// that still pass it). Migration uses CodexAppServerClient.shared.
     func launchAgent(
         prompt: String,
         screenshots: [(data: Data, label: String)],
@@ -38,21 +48,182 @@ final class AgentSessionManager: ObservableObject {
         sessions.append(session)
         let sessionID = session.id
 
+        // Compose the prompt with memory context; codex app-server has no
+        // built-in memory injection, so we prepend it ourselves.
+        let composedPrompt: String = {
+            if memoryContextBlock.isEmpty { return prompt }
+            return memoryContextBlock + "\n\n" + prompt
+        }()
+
         Task {
             do {
-                let result = try await codexClient.runAgentTask(
-                    prompt: prompt,
-                    screenshots: screenshots,
-                    memoryContextBlock: memoryContextBlock,
-                    onProgressChunk: { _ in }
+                Self.ensureWorkspaceExists()
+                let threadID = try await CodexAppServerClient.shared.startThread(
+                    cwd: Self.workspaceRoot
                 )
-                markSession(id: sessionID, status: .completed, result: result)
-                onComplete(result)
+                self.setThreadID(id: sessionID, threadID: threadID)
+
+                let result = try await CodexAppServerClient.shared.startTurn(
+                    threadID: threadID,
+                    prompt: composedPrompt,
+                    onEvent: { [weak self] event in
+                        self?.handleThreadEvent(sessionID: sessionID, event: event)
+                    }
+                )
+
+                let stillExists = sessions.contains(where: { $0.id == sessionID })
+                if stillExists {
+                    markSession(id: sessionID, status: .completed, result: result)
+                    onComplete(result)
+                } else {
+                    print("🛑 Session was dismissed mid-run — skipping completion TTS")
+                }
             } catch {
-                markSession(id: sessionID, status: .failed, result: error.localizedDescription)
+                let stillExists = sessions.contains(where: { $0.id == sessionID })
+                if stillExists {
+                    markSession(id: sessionID, status: .failed, result: error.localizedDescription)
+                }
             }
             scheduleRemoval(of: sessionID, after: Self.completedSessionLingerSeconds)
         }
+    }
+
+    /// Sends a follow-up prompt to an existing thread on the codex app-server.
+    /// The session goes back to .running while the new turn streams in;
+    /// new output is appended below the prior transcript so the conversation
+    /// history stays visible in the panel.
+    func sendFollowUp(
+        sessionID: UUID,
+        prompt: String,
+        codexClient: CodexCLIClient
+    ) {
+        guard let index = sessions.firstIndex(where: { $0.id == sessionID }) else { return }
+        guard let threadID = sessions[index].codexThreadID else {
+            sessions[index].liveOutput += "\n\n[follow-up failed: no Codex thread id captured]"
+            return
+        }
+
+        let header = "\n\n--- you ---\n\(prompt)\n\n--- codex ---\n"
+        sessions[index].liveOutput += header
+        sessions[index].status = .running
+        sessions[index].result = nil
+
+        Task {
+            do {
+                let result = try await CodexAppServerClient.shared.startTurn(
+                    threadID: threadID,
+                    prompt: prompt,
+                    onEvent: { [weak self] event in
+                        // For follow-ups we keep the prior content + header
+                        // intact, then replace the post-header tail with
+                        // the latest streamed text.
+                        self?.handleFollowUpEvent(sessionID: sessionID, header: header, event: event)
+                    }
+                )
+                let stillExists = sessions.contains(where: { $0.id == sessionID })
+                if stillExists {
+                    markSession(id: sessionID, status: .completed, result: result)
+                }
+            } catch {
+                let stillExists = sessions.contains(where: { $0.id == sessionID })
+                if stillExists {
+                    markSession(id: sessionID, status: .failed, result: error.localizedDescription)
+                }
+            }
+            scheduleRemoval(of: sessionID, after: Self.completedSessionLingerSeconds)
+        }
+    }
+
+    // MARK: - Stream → liveOutput
+
+    /// Translate a CodexThreadEvent into a panel-render-friendly text update.
+    /// Format mirrors what the old codex exec parser produced:
+    ///   - agent_message → prose
+    ///   - command_execution → "$ <cmd>\n<output>"
+    ///   - file_change → "+ /path" / "✎ /path"
+    private func handleThreadEvent(sessionID: UUID, event: CodexThreadEvent) {
+        guard let index = sessions.firstIndex(where: { $0.id == sessionID }) else { return }
+        switch event {
+        case .agentMessageDelta(let delta):
+            appendToLiveOutput(at: index, sessionID: sessionID, text: delta, separator: nil)
+        case .agentMessageComplete(let text):
+            // Some servers send a final complete message instead of deltas.
+            // If we never saw deltas, replace; otherwise leave the deltas alone.
+            if sessions[index].liveOutput.isEmpty {
+                sessions[index].liveOutput = text
+            }
+        case .shellCommand(let command, let output):
+            let trimmedOut = output?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let line = trimmedOut.isEmpty ? "$ \(command)" : "$ \(command)\n\(trimmedOut)"
+            appendToLiveOutput(at: index, sessionID: sessionID, text: line, separator: "\n\n")
+        case .fileChange(let paths, let kinds):
+            let lines = zip(paths, kinds + Array(repeating: "edit", count: max(0, paths.count - kinds.count))).map { path, kind -> String in
+                let icon = kind == "add" ? "+" : (kind == "delete" ? "−" : "✎")
+                return "\(icon) \(path)"
+            }
+            appendToLiveOutput(at: index, sessionID: sessionID, text: lines.joined(separator: "\n"), separator: "\n\n")
+        case .turnCompleted, .turnFailed:
+            // Terminal events are handled by the awaiting startTurn caller.
+            break
+        case .info(let msg):
+            print("ℹ️ codex info (\(sessionID.uuidString.prefix(8))): \(msg)")
+        }
+    }
+
+    /// Variant for follow-up turns — preserves prior output + header marker
+    /// and replaces only the trailing chunk so the user sees the new turn
+    /// growing under the "--- codex ---" divider.
+    private func handleFollowUpEvent(sessionID: UUID, header: String, event: CodexThreadEvent) {
+        guard let index = sessions.firstIndex(where: { $0.id == sessionID }) else { return }
+        let current = sessions[index].liveOutput
+        guard let markerRange = current.range(of: header) else {
+            // Header missing (shouldn't happen) — fall back to standard append
+            handleThreadEvent(sessionID: sessionID, event: event)
+            return
+        }
+        let prefix = String(current[..<markerRange.upperBound])
+
+        switch event {
+        case .agentMessageDelta(let delta):
+            sessions[index].liveOutput = prefix + (current[markerRange.upperBound...] + delta)
+        case .agentMessageComplete(let text):
+            sessions[index].liveOutput = prefix + text
+        case .shellCommand(let command, let output):
+            let trimmedOut = output?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let line = trimmedOut.isEmpty ? "$ \(command)" : "$ \(command)\n\(trimmedOut)"
+            let suffix = String(current[markerRange.upperBound...])
+            let separator = suffix.isEmpty ? "" : "\n\n"
+            sessions[index].liveOutput = prefix + suffix + separator + line
+        case .fileChange(let paths, let kinds):
+            let lines = zip(paths, kinds + Array(repeating: "edit", count: max(0, paths.count - kinds.count))).map { path, kind -> String in
+                let icon = kind == "add" ? "+" : (kind == "delete" ? "−" : "✎")
+                return "\(icon) \(path)"
+            }
+            let suffix = String(current[markerRange.upperBound...])
+            let separator = suffix.isEmpty ? "" : "\n\n"
+            sessions[index].liveOutput = prefix + suffix + separator + lines.joined(separator: "\n")
+        case .turnCompleted, .turnFailed, .info:
+            break
+        }
+    }
+
+    private func appendToLiveOutput(at index: Int, sessionID: UUID, text: String, separator: String?) {
+        let prev = sessions[index].liveOutput
+        let prevLength = prev.count
+        let glued: String
+        if prev.isEmpty {
+            glued = text
+        } else if let sep = separator {
+            glued = prev + sep + text
+        } else {
+            glued = prev + text
+        }
+        if prevLength == 0 && !glued.isEmpty {
+            print("📝 Session \(sessionID.uuidString.prefix(8)): first output chunk (\(glued.count) chars)")
+        } else if (glued.count - prevLength) > 500 {
+            print("📝 Session \(sessionID.uuidString.prefix(8)): now \(glued.count) chars")
+        }
+        sessions[index].liveOutput = glued
     }
 
     // MARK: - State updates
@@ -61,22 +232,59 @@ final class AgentSessionManager: ObservableObject {
         guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
         sessions[index].status = status
         sessions[index].result = result
+        let outputLen = sessions[index].liveOutput.count
+        let resultLen = result?.count ?? 0
+        print("✅ Session \(id.uuidString.prefix(8)) → \(status) (liveOutput: \(outputLen) chars, result: \(resultLen) chars)")
+    }
+
+    private func setThreadID(id: UUID, threadID: String) {
+        guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
+        sessions[index].codexThreadID = threadID
+        print("🧵 Session \(id.uuidString.prefix(8)) → thread \(threadID.prefix(8))")
     }
 
     private func scheduleRemoval(of id: UUID, after seconds: Double) {
         Task {
             try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-            sessions.removeAll { $0.id == id }
+            // If the session has been re-engaged (e.g. user is sending a
+            // follow-up turn), leave it alone.
+            guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
+            if sessions[index].status == .running { return }
+            removeSession(id: id)
         }
     }
 
+    /// Removes a session AND fully tears down its codex thread so the
+    /// agent doesn't keep running invisibly after the icon disappears:
+    ///   1. turn/interrupt — stops the in-flight turn (no-op if already done)
+    ///   2. thread/archive — closes the thread server-side so codex frees
+    ///      its resources and stops emitting notifications
     func removeSession(id: UUID) {
+        guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
+        let threadID = sessions[index].codexThreadID
+        let wasRunning = sessions[index].status == .running
+
+        if let threadID {
+            print("🛑 Tearing down codex thread \(threadID.prefix(8)) for session \(id.uuidString.prefix(8)) (running=\(wasRunning))")
+            Task {
+                if wasRunning {
+                    await CodexAppServerClient.shared.interruptTurn(threadID: threadID)
+                }
+                await CodexAppServerClient.shared.archiveThread(threadID: threadID)
+            }
+        }
         sessions.removeAll { $0.id == id }
     }
 
     // MARK: - Helpers
 
     var hasAnySessions: Bool { !sessions.isEmpty }
-
     var runningSessionCount: Int { sessions.filter { $0.status == .running }.count }
+
+    private static func ensureWorkspaceExists() {
+        try? FileManager.default.createDirectory(
+            atPath: workspaceRoot,
+            withIntermediateDirectories: true
+        )
+    }
 }

--- a/leanring-buddy/AgentSessionManager.swift
+++ b/leanring-buddy/AgentSessionManager.swift
@@ -1,0 +1,82 @@
+//
+//  AgentSessionManager.swift
+//  leanring-buddy
+//
+//  Manages multiple concurrent Codex agent sessions — the "siblings".
+//  Each call to launchAgent() spawns a new background Task that runs
+//  Codex independently, so several agents can work simultaneously
+//  without blocking each other or the voice UI.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+final class AgentSessionManager: ObservableObject {
+    @Published private(set) var sessions: [AgentSession] = []
+
+    private var colorCycleIndex = 0
+
+    // How long a completed/failed session lingers before being removed from the list.
+    private static let completedSessionLingerSeconds: Double = 8
+
+    // MARK: - Launch
+
+    /// Spawns a new agent for the given prompt and returns immediately.
+    /// The agent runs in the background; onComplete is called (on MainActor) when it finishes.
+    func launchAgent(
+        prompt: String,
+        screenshots: [(data: Data, label: String)],
+        memoryContextBlock: String,
+        codexClient: CodexCLIClient,
+        onComplete: @escaping @MainActor (String) -> Void
+    ) {
+        let color = AgentSession.palette[colorCycleIndex % AgentSession.palette.count]
+        colorCycleIndex += 1
+
+        let session = AgentSession(taskDescription: prompt, triangleColor: color)
+        sessions.append(session)
+        let sessionID = session.id
+
+        Task {
+            do {
+                let result = try await codexClient.runAgentTask(
+                    prompt: prompt,
+                    screenshots: screenshots,
+                    memoryContextBlock: memoryContextBlock,
+                    onProgressChunk: { _ in }
+                )
+                markSession(id: sessionID, status: .completed, result: result)
+                onComplete(result)
+            } catch {
+                markSession(id: sessionID, status: .failed, result: error.localizedDescription)
+            }
+            scheduleRemoval(of: sessionID, after: Self.completedSessionLingerSeconds)
+        }
+    }
+
+    // MARK: - State updates
+
+    private func markSession(id: UUID, status: AgentSessionStatus, result: String?) {
+        guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
+        sessions[index].status = status
+        sessions[index].result = result
+    }
+
+    private func scheduleRemoval(of id: UUID, after seconds: Double) {
+        Task {
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            sessions.removeAll { $0.id == id }
+        }
+    }
+
+    func removeSession(id: UUID) {
+        sessions.removeAll { $0.id == id }
+    }
+
+    // MARK: - Helpers
+
+    var hasAnySessions: Bool { !sessions.isEmpty }
+
+    var runningSessionCount: Int { sessions.filter { $0.status == .running }.count }
+}

--- a/leanring-buddy/AgentSiblingsOverlayWindow.swift
+++ b/leanring-buddy/AgentSiblingsOverlayWindow.swift
@@ -20,7 +20,11 @@ import SwiftUI
 final class AgentSiblingsOverlayWindow: NSPanel {
     private var hostingController: NSHostingController<AgentSiblingsContainerView>?
 
-    init(sessionManager: AgentSessionManager) {
+    init(
+        sessionManager: AgentSessionManager,
+        onSelectSession: @escaping (UUID) -> Void,
+        onSessionsEmpty: @escaping () -> Void
+    ) {
         // Start with a compact frame — SwiftUI content drives the actual size.
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: 90, height: 90),
@@ -38,7 +42,11 @@ final class AgentSiblingsOverlayWindow: NSPanel {
         ignoresMouseEvents = false  // siblings are interactive (click to dismiss)
         collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
 
-        let rootView = AgentSiblingsContainerView(sessionManager: sessionManager)
+        let rootView = AgentSiblingsContainerView(
+            sessionManager: sessionManager,
+            onSelectSession: onSelectSession,
+            onSessionsEmpty: onSessionsEmpty
+        )
         let hc = NSHostingController(rootView: rootView)
         hostingController = hc
         contentView = hc.view
@@ -68,11 +76,35 @@ final class AgentSiblingsOverlayWindow: NSPanel {
 final class AgentSiblingsWindowManager {
     private var window: AgentSiblingsOverlayWindow?
 
-    func show(sessionManager: AgentSessionManager) {
+    /// Shows the siblings overlay. `onSelectSession` is called with the
+    /// session id and the overlay window's screen frame whenever the user
+    /// taps a sibling icon — CompanionManager uses this to position the
+    /// click-to-inspect detail panel next to the column of icons.
+    func show(
+        sessionManager: AgentSessionManager,
+        onSelectSession: @escaping (UUID, NSRect) -> Void
+    ) {
         if window == nil {
-            window = AgentSiblingsOverlayWindow(sessionManager: sessionManager)
+            // Wrap the (UUID) callback so it includes the live overlay frame
+            // at click time, used by the detail window for anchoring.
+            let wrappedSelect: (UUID) -> Void = { [weak self] sessionID in
+                guard let frame = self?.window?.frame else {
+                    onSelectSession(sessionID, .zero)
+                    return
+                }
+                onSelectSession(sessionID, frame)
+            }
+            window = AgentSiblingsOverlayWindow(
+                sessionManager: sessionManager,
+                onSelectSession: wrappedSelect,
+                onSessionsEmpty: { [weak self] in self?.hide() }
+            )
+            print("🪟 Created AgentSiblingsOverlayWindow")
         }
         window?.orderFront(nil)
+        if let frame = window?.frame {
+            print("🪟 Sibling overlay shown at frame: \(frame), visible: \(window?.isVisible ?? false), screen: \(window?.screen?.localizedName ?? "nil")")
+        }
     }
 
     func hide() {
@@ -84,13 +116,17 @@ final class AgentSiblingsWindowManager {
 
 struct AgentSiblingsContainerView: View {
     @ObservedObject var sessionManager: AgentSessionManager
+    let onSelectSession: (UUID) -> Void
+    let onSessionsEmpty: () -> Void
 
     var body: some View {
         VStack(spacing: 10) {
             ForEach(sessionManager.sessions) { session in
-                AgentSiblingIconView(session: session) {
-                    sessionManager.removeSession(id: session.id)
-                }
+                AgentSiblingIconView(
+                    session: session,
+                    onSelect: { onSelectSession(session.id) },
+                    onDismiss: { sessionManager.removeSession(id: session.id) }
+                )
                 .transition(.asymmetric(
                     insertion: .scale(scale: 0.6).combined(with: .opacity),
                     removal: .scale(scale: 0.6).combined(with: .opacity)
@@ -99,6 +135,16 @@ struct AgentSiblingsContainerView: View {
         }
         .padding(8)
         .animation(.spring(response: 0.35, dampingFraction: 0.75), value: sessionManager.sessions.map { $0.id })
+        .onAppear {
+            if sessionManager.sessions.isEmpty {
+                onSessionsEmpty()
+            }
+        }
+        .onChange(of: sessionManager.sessions.count) { count in
+            if count == 0 {
+                onSessionsEmpty()
+            }
+        }
     }
 }
 
@@ -106,6 +152,7 @@ struct AgentSiblingsContainerView: View {
 
 struct AgentSiblingIconView: View {
     let session: AgentSession
+    let onSelect: () -> Void
     let onDismiss: () -> Void
 
     @State private var isHovered = false
@@ -154,8 +201,16 @@ struct AgentSiblingIconView: View {
             withAnimation(.easeInOut(duration: 0.15)) { isHovered = hovering }
         }
         .onTapGesture {
-            // Tap to dismiss completed/failed sessions; ignore taps on running ones.
-            if session.status != .running { onDismiss() }
+            // Single click — open the detail panel for ANY session (running,
+            // completed, or failed). Long-press on completed sessions removes
+            // them early; otherwise they auto-fade after the linger window.
+            onSelect()
+        }
+        .onLongPressGesture(minimumDuration: 0.6) {
+            // Long-press dismisses ANY session (running, done, or failed).
+            // For running sessions this also interrupts the codex turn so
+            // the agent stops doing work in the background.
+            onDismiss()
         }
         .help(session.taskDescription)
     }

--- a/leanring-buddy/AgentSiblingsOverlayWindow.swift
+++ b/leanring-buddy/AgentSiblingsOverlayWindow.swift
@@ -1,0 +1,203 @@
+//
+//  AgentSiblingsOverlayWindow.swift
+//  leanring-buddy
+//
+//  Floating panel that shows "mini clicky siblings" — one icon per running
+//  or recently completed Codex agent. Inspired by the sibling icons seen in
+//  the original Clicky app: dark rounded squares with a colored triangle and
+//  a small status dot (blue = running, green = done, red = failed).
+//
+//  The window lives on top of all other windows (level .floating), never
+//  steals focus, and joins all Spaces so it persists across virtual desktops.
+//  It auto-hides when there are no sessions and reappears when new agents launch.
+//
+
+import AppKit
+import SwiftUI
+
+// MARK: - Siblings window
+
+final class AgentSiblingsOverlayWindow: NSPanel {
+    private var hostingController: NSHostingController<AgentSiblingsContainerView>?
+
+    init(sessionManager: AgentSessionManager) {
+        // Start with a compact frame — SwiftUI content drives the actual size.
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 90, height: 90),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        isOpaque = false
+        backgroundColor = .clear
+        level = .floating
+        isReleasedWhenClosed = false
+        hasShadow = false
+        hidesOnDeactivate = false
+        ignoresMouseEvents = false  // siblings are interactive (click to dismiss)
+        collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+
+        let rootView = AgentSiblingsContainerView(sessionManager: sessionManager)
+        let hc = NSHostingController(rootView: rootView)
+        hostingController = hc
+        contentView = hc.view
+        contentView?.wantsLayer = true
+        contentView?.layer?.backgroundColor = NSColor.clear.cgColor
+
+        // Position: right side of primary screen, vertically centered.
+        positionOnScreen()
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    private func positionOnScreen() {
+        guard let screen = NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+        // Anchor to the right edge with 16pt inset, vertically centered.
+        let windowX = screenFrame.maxX - 90 - 16
+        let windowY = screenFrame.midY - 200
+        setFrameOrigin(NSPoint(x: windowX, y: windowY))
+    }
+}
+
+// MARK: - Manager that owns the window
+
+@MainActor
+final class AgentSiblingsWindowManager {
+    private var window: AgentSiblingsOverlayWindow?
+
+    func show(sessionManager: AgentSessionManager) {
+        if window == nil {
+            window = AgentSiblingsOverlayWindow(sessionManager: sessionManager)
+        }
+        window?.orderFront(nil)
+    }
+
+    func hide() {
+        window?.orderOut(nil)
+    }
+}
+
+// MARK: - Container SwiftUI view
+
+struct AgentSiblingsContainerView: View {
+    @ObservedObject var sessionManager: AgentSessionManager
+
+    var body: some View {
+        VStack(spacing: 10) {
+            ForEach(sessionManager.sessions) { session in
+                AgentSiblingIconView(session: session) {
+                    sessionManager.removeSession(id: session.id)
+                }
+                .transition(.asymmetric(
+                    insertion: .scale(scale: 0.6).combined(with: .opacity),
+                    removal: .scale(scale: 0.6).combined(with: .opacity)
+                ))
+            }
+        }
+        .padding(8)
+        .animation(.spring(response: 0.35, dampingFraction: 0.75), value: sessionManager.sessions.map { $0.id })
+    }
+}
+
+// MARK: - Single sibling icon
+
+struct AgentSiblingIconView: View {
+    let session: AgentSession
+    let onDismiss: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            // Dark rounded square background
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(hex: "#1C1F1E"))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+                )
+                .shadow(color: .black.opacity(0.5), radius: 8, x: 0, y: 4)
+                .frame(width: 64, height: 64)
+
+            // Colored triangle
+            Triangle()
+                .fill(session.triangleColor)
+                .shadow(color: session.triangleColor.opacity(0.5), radius: 6)
+                .frame(width: 30, height: 30)
+                .frame(width: 64, height: 64) // center within icon
+
+            // Status dot — top-right corner
+            statusDot
+                .offset(x: 4, y: -4)
+
+            // Running shimmer ring
+            if session.status == .running {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(session.triangleColor.opacity(0.3), lineWidth: 1.5)
+                    .frame(width: 64, height: 64)
+                    .scaleEffect(isHovered ? 1.05 : 1.0)
+            }
+        }
+        .frame(width: 72, height: 72)
+        .overlay(alignment: .leading) {
+            // Task label — shown on hover to the left of the icon
+            if isHovered {
+                taskLabel
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                    .offset(x: -8, y: 0)
+            }
+        }
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) { isHovered = hovering }
+        }
+        .onTapGesture {
+            // Tap to dismiss completed/failed sessions; ignore taps on running ones.
+            if session.status != .running { onDismiss() }
+        }
+        .help(session.taskDescription)
+    }
+
+    @ViewBuilder
+    private var statusDot: some View {
+        Circle()
+            .fill(dotColor)
+            .frame(width: 10, height: 10)
+            .overlay(Circle().stroke(Color(hex: "#1C1F1E"), lineWidth: 1.5))
+            .shadow(color: dotColor.opacity(0.8), radius: 3)
+    }
+
+    private var dotColor: Color {
+        switch session.status {
+        case .running:   return Color(hex: "#3B82F6") // blue
+        case .completed: return Color(hex: "#22C55E") // green
+        case .failed:    return Color(hex: "#EF4444") // red
+        }
+    }
+
+    private var taskLabel: some View {
+        HStack(spacing: 6) {
+            Text(session.taskDescription.prefix(40) + (session.taskDescription.count > 40 ? "..." : ""))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(Color(hex: "#ECEEED"))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(hex: "#1C1F1E"))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+                )
+                .shadow(color: .black.opacity(0.4), radius: 6, x: 0, y: 3)
+        )
+        .frame(maxWidth: 180, alignment: .trailing)
+        .offset(x: -76) // position to the left of the icon
+    }
+}

--- a/leanring-buddy/AssemblyAIStreamingTranscriptionProvider.swift
+++ b/leanring-buddy/AssemblyAIStreamingTranscriptionProvider.swift
@@ -17,14 +17,30 @@ struct AssemblyAIStreamingTranscriptionProviderError: LocalizedError {
 }
 
 final class AssemblyAIStreamingTranscriptionProvider: BuddyTranscriptionProvider {
-    /// AssemblyAI token endpoint — fetched directly using the API key.
-    private static let assemblyAITokenURL = "https://streaming.assemblyai.com/v3/token?expires_in_seconds=480"
+    private static let directAssemblyAITokenURL = URL(
+        string: "https://streaming.assemblyai.com/v3/token?expires_in_seconds=480"
+    )!
+    private static let tokenProxyConfigKeys = [
+        "ClickyAssemblyAITokenProxyURL",
+        "AssemblyAITokenProxyURL"
+    ]
+    private static let tokenProxyEnvironmentKey = "CLICKY_ASSEMBLYAI_TOKEN_PROXY_URL"
+
+    private static var directAPIKey: String {
+        DirectAPICredentials.assemblyAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     let displayName = "AssemblyAI"
     let requiresSpeechRecognitionPermission = false
 
-    var isConfigured: Bool { true }
-    var unavailableExplanation: String? { nil }
+    var isConfigured: Bool {
+        Self.configuredTokenProxyURL() != nil || !Self.directAPIKey.isEmpty
+    }
+    var unavailableExplanation: String? {
+        isConfigured
+            ? nil
+            : "AssemblyAI is not configured. Add an AssemblyAI API key or ClickyAssemblyAITokenProxyURL."
+    }
 
     /// Single long-lived URLSession shared across all streaming sessions.
     /// Creating and invalidating a URLSession per session corrupts the OS
@@ -38,7 +54,7 @@ final class AssemblyAIStreamingTranscriptionProvider: BuddyTranscriptionProvider
         onFinalTranscriptReady: @escaping (String) -> Void,
         onError: @escaping (Error) -> Void
     ) async throws -> any BuddyStreamingTranscriptionSession {
-        // Fetch a fresh temporary token from the proxy before each session
+        // Fetch a fresh temporary token before each session.
         let temporaryToken = try await fetchTemporaryToken()
         print("🎙️ AssemblyAI: fetched temporary token (\(temporaryToken.prefix(20))...)")
 
@@ -56,14 +72,38 @@ final class AssemblyAIStreamingTranscriptionProvider: BuddyTranscriptionProvider
         return session
     }
 
-    /// Calls AssemblyAI directly to get a short-lived streaming token.
+    /// Fetches a short-lived AssemblyAI streaming token. Production can use a
+    /// configured Worker proxy; local development can opt into a proxy with
+    /// `CLICKY_ASSEMBLYAI_TOKEN_PROXY_URL`. Otherwise we call AssemblyAI
+    /// directly with the local direct API credential.
     private func fetchTemporaryToken() async throws -> String {
-        var request = URLRequest(url: URL(string: Self.assemblyAITokenURL)!)
+        if let proxyURL = Self.configuredTokenProxyURL() {
+            return try await fetchTemporaryTokenFromProxy(proxyURL)
+        }
+
+        let apiKey = Self.directAPIKey
+        guard !apiKey.isEmpty else {
+            throw AssemblyAIStreamingTranscriptionProviderError(
+                message: "AssemblyAI is not configured. Add an API key or ClickyAssemblyAITokenProxyURL."
+            )
+        }
+
+        var request = URLRequest(url: Self.directAssemblyAITokenURL)
         request.httpMethod = "GET"
-        request.setValue(DirectAPICredentials.assemblyAIAPIKey, forHTTPHeaderField: "Authorization")
+        request.setValue(apiKey, forHTTPHeaderField: "Authorization")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        return try decodeTemporaryTokenResponse(data: data, response: response)
+    }
+
+    private func fetchTemporaryTokenFromProxy(_ proxyURL: URL) async throws -> String {
+        var request = URLRequest(url: proxyURL)
+        request.httpMethod = "POST"
 
         let (data, response) = try await URLSession.shared.data(for: request)
+        return try decodeTemporaryTokenResponse(data: data, response: response)
+    }
 
+    private func decodeTemporaryTokenResponse(data: Data, response: URLResponse) throws -> String {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
@@ -76,11 +116,27 @@ final class AssemblyAIStreamingTranscriptionProvider: BuddyTranscriptionProvider
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let token = json["token"] as? String else {
             throw AssemblyAIStreamingTranscriptionProviderError(
-                message: "Invalid token response from proxy."
+                message: "Invalid AssemblyAI token response."
             )
         }
 
         return token
+    }
+
+    private static func configuredTokenProxyURL() -> URL? {
+        for key in tokenProxyConfigKeys {
+            if let urlString = AppBundleConfiguration.stringValue(forKey: key),
+               let url = URL(string: urlString) {
+                return url
+            }
+        }
+        if let urlString = ProcessInfo.processInfo.environment[tokenProxyEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !urlString.isEmpty,
+           let url = URL(string: urlString) {
+            return url
+        }
+        return nil
     }
 }
 

--- a/leanring-buddy/CodexAppServerClient.swift
+++ b/leanring-buddy/CodexAppServerClient.swift
@@ -1,0 +1,687 @@
+//
+//  CodexAppServerClient.swift
+//  leanring-buddy
+//
+//  Long-lived JSON-RPC 2.0 client for `codex app-server` (the same protocol
+//  the official Codex VS Code extension uses). Replaces the old `codex exec`
+//  subprocess-per-task model with a single persistent server that hosts
+//  multiple concurrent "threads" — one per Clicky sibling.
+//
+//  Protocol (newline-delimited JSON over stdio):
+//    1. App sends `initialize` with clientInfo  → server returns hello
+//    2. App sends `thread/start` per sibling    → server returns thread ID
+//    3. App sends `turn/start` with the prompt  → server streams agent_message
+//       deltas via notifications, plus item.completed events for shell
+//       commands and file changes.
+//    4. App sends `turn/interrupt` to cancel    (used when user dismisses)
+//
+//  Each agent message / shell command / file change arrives as a JSON-RPC
+//  notification (no `id` field). The client routes those to the per-thread
+//  callbacks set up by AgentSessionManager.
+//
+
+import Foundation
+
+// MARK: - Errors
+
+enum CodexAppServerError: LocalizedError {
+    case binaryNotFound
+    case processLaunchFailed(Error)
+    case serverDied
+    case rpcError(code: Int, message: String)
+    case unexpectedResponse(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .binaryNotFound:
+            return "Codex CLI binary not found."
+        case .processLaunchFailed(let err):
+            return "Failed to launch codex app-server: \(err.localizedDescription)"
+        case .serverDied:
+            return "codex app-server exited unexpectedly."
+        case .rpcError(let code, let message):
+            return "Codex RPC error \(code): \(message)"
+        case .unexpectedResponse(let detail):
+            return "Unexpected response from codex app-server: \(detail)"
+        }
+    }
+}
+
+// MARK: - Stream events surfaced to AgentSessionManager
+
+/// A single delta emitted by codex while a turn is in progress.
+/// AgentSessionManager translates these into the panel's live output.
+enum CodexThreadEvent: Sendable {
+    case agentMessageDelta(String)
+    case agentMessageComplete(String)
+    case shellCommand(command: String, output: String?)
+    case fileChange(paths: [String], kinds: [String])
+    case turnCompleted(finalText: String)
+    case turnFailed(message: String)
+    case info(String)
+}
+
+// MARK: - Client
+
+@MainActor
+final class CodexAppServerClient {
+
+    // MARK: - Singleton (one server for the whole app)
+
+    static let shared = CodexAppServerClient()
+
+    // MARK: - Private state
+
+    private var process: Process?
+    private var stdinHandle: FileHandle?
+    private var stdoutHandle: FileHandle?
+    private var stderrHandle: FileHandle?
+
+    private var isInitialized = false
+    private var initializeTask: Task<Void, Error>?
+
+    /// Buffer for incoming JSON lines — stdout chunks may not align to newlines.
+    private var stdoutBuffer = ""
+
+    private var nextRequestID: Int = 1
+    /// Pending request ID → continuation. When a JSON-RPC response arrives
+    /// with a matching id, we resume the awaiting caller.
+    private var pendingRequests: [Int: CheckedContinuation<[String: Any], Error>] = [:]
+
+    /// Per-thread event handlers. Notifications carry a thread ID; we route
+    /// them to the right sibling's callback.
+    private var threadEventHandlers: [String: @MainActor @Sendable (CodexThreadEvent) -> Void] = [:]
+    /// Per-thread active turn continuations. Closing a sibling while a turn is
+    /// running must resume this continuation, otherwise the Swift Task waits
+    /// forever even after the UI is gone.
+    private var threadTurnContinuations: [String: CheckedContinuation<String, Error>] = [:]
+    /// Tracks which threads are currently running a turn (for interrupt).
+    private var threadRunning: [String: Bool] = [:]
+    /// Active turn ID per thread. `turn/interrupt` requires both threadId and
+    /// turnId, so we capture it from the turn/start response or turn/started
+    /// notification before attempting cancellation.
+    private var activeTurnIDs: [String: String] = [:]
+
+    // MARK: - Public surface
+
+    /// Whether the codex binary exists and the server CAN be launched.
+    /// Mirrors CodexCLIClient.isAvailable() so existing call sites keep working.
+    static func isAvailable() -> Bool {
+        return findBinaryPath() != nil
+    }
+
+    /// Starts a fresh thread and returns its ID. If the server hasn't been
+    /// initialized yet, initializes it lazily.
+    func startThread(
+        cwd: String,
+        sandbox: String = "workspace-write",
+        approvalPolicy: String = "never"
+    ) async throws -> String {
+        try await ensureInitialized()
+        let params: [String: Any] = [
+            "cwd": cwd,
+            "sandbox": sandbox,
+            "approvalPolicy": approvalPolicy,
+        ]
+        let result = try await sendRequest(method: "thread/start", params: params)
+        guard let thread = result["thread"] as? [String: Any],
+              let threadID = thread["id"] as? String else {
+            throw CodexAppServerError.unexpectedResponse("thread/start: missing thread.id")
+        }
+        return threadID
+    }
+
+    /// Sends a user prompt as a new turn on the given thread. Streams events
+    /// (deltas, shell commands, file changes) via `onEvent`. Returns when
+    /// the turn completes (successfully or with an error event).
+    func startTurn(
+        threadID: String,
+        prompt: String,
+        onEvent: @escaping @MainActor @Sendable (CodexThreadEvent) -> Void
+    ) async throws -> String {
+        try await ensureInitialized()
+        threadRunning[threadID] = true
+
+        // Install the terminal-event-aware handler BEFORE sending turn/start,
+        // so notifications that arrive between submission and the response
+        // can't be lost. Both the user's onEvent and our terminal-event
+        // tracker run from the same callback.
+        return try await withCheckedThrowingContinuation { continuation in
+            var accumulatedText = ""
+            self.threadTurnContinuations[threadID] = continuation
+
+            self.threadEventHandlers[threadID] = { [weak self] event in
+                onEvent(event)
+                switch event {
+                case .agentMessageDelta(let delta):
+                    accumulatedText += delta
+                case .agentMessageComplete(let text):
+                    if !text.isEmpty { accumulatedText = text }
+                case .turnCompleted(let finalText):
+                    let finalValue = !finalText.isEmpty ? finalText : accumulatedText
+                    self?.finishTurn(threadID: threadID, result: .success(finalValue))
+                case .turnFailed(let message):
+                    self?.finishTurn(
+                        threadID: threadID,
+                        result: .failure(CodexAppServerError.rpcError(code: -1, message: message))
+                    )
+                default:
+                    break
+                }
+            }
+
+            let params: [String: Any] = [
+                "threadId": threadID,
+                "input": [["type": "text", "text": prompt]],
+            ]
+
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let response = try await self.sendRequest(method: "turn/start", params: params)
+                    if let turn = response["turn"] as? [String: Any],
+                       let turnID = turn["id"] as? String,
+                       self.threadRunning[threadID] == true {
+                        self.activeTurnIDs[threadID] = turnID
+                    }
+                } catch {
+                    self.finishTurn(threadID: threadID, result: .failure(error))
+                }
+            }
+        }
+    }
+
+    /// Interrupts a running turn so the codex agent stops mid-execution.
+    /// Used by AgentSessionManager.removeSession() when the user dismisses
+    /// a sibling that's still working.
+    func interruptTurn(threadID: String) async {
+        guard threadRunning[threadID] == true || threadTurnContinuations[threadID] != nil else { return }
+        if activeTurnIDs[threadID] == nil {
+            for _ in 0..<10 where activeTurnIDs[threadID] == nil {
+                try? await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
+        guard let turnID = activeTurnIDs[threadID] else {
+            print("⚠️ turn/interrupt skipped for thread \(threadID.prefix(8)): no active turn id yet")
+            return
+        }
+        let params: [String: Any] = ["threadId": threadID, "turnId": turnID]
+        _ = try? await sendRequest(method: "turn/interrupt", params: params)
+        print("🛑 turn/interrupt sent for thread \(threadID.prefix(8)) turn \(turnID.prefix(8))")
+    }
+
+    /// Archives a thread so the server frees its resources. Called after
+    /// the user dismisses a sibling — without this, threads leak on the
+    /// app-server even after their turn completes/interrupts.
+    func archiveThread(threadID: String) async {
+        cancelLocalTurnWaiter(threadID: threadID, reason: "Codex session was closed.")
+        let params: [String: Any] = ["threadId": threadID]
+        _ = try? await sendRequest(method: "thread/archive", params: params)
+        _ = try? await sendRequest(method: "thread/unsubscribe", params: params)
+        threadEventHandlers.removeValue(forKey: threadID)
+        threadRunning.removeValue(forKey: threadID)
+        activeTurnIDs.removeValue(forKey: threadID)
+        print("🗑️ thread/archive + thread/unsubscribe sent for thread \(threadID.prefix(8))")
+    }
+
+    private func finishTurn(threadID: String, result: Result<String, Error>) {
+        guard let continuation = threadTurnContinuations.removeValue(forKey: threadID) else { return }
+        threadRunning[threadID] = false
+        activeTurnIDs.removeValue(forKey: threadID)
+        threadEventHandlers.removeValue(forKey: threadID)
+        switch result {
+        case .success(let value):
+            continuation.resume(returning: value)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
+    }
+
+    private func cancelLocalTurnWaiter(threadID: String, reason: String) {
+        finishTurn(
+            threadID: threadID,
+            result: .failure(CodexAppServerError.rpcError(code: -1, message: reason))
+        )
+    }
+
+    /// Synchronously terminates the codex app-server subprocess AND every
+    /// descendant (the node wrapper, the actual codex binary, any child
+    /// shells codex spawned). Called from NSApplicationWillTerminate so
+    /// codex doesn't outlive Clicky. Without this, every Clicky restart
+    /// leaks an app-server tree — they end up running indefinitely
+    /// consuming the user's quota.
+    func shutdownSync() {
+        guard let p = process else { return }
+        let rootPID = p.processIdentifier
+        guard rootPID > 0 else { return }
+        print("🛑 Shutting down codex app-server tree starting at pid \(rootPID) on app exit")
+
+        // Walk the live ps table and collect every descendant of rootPID.
+        let descendants = Self.descendantPIDs(of: rootPID)
+        let allPIDs = [rootPID] + descendants
+        print("🛑 Killing \(allPIDs.count) process(es) in tree: \(allPIDs)")
+
+        // SIGTERM first for graceful shutdown.
+        for pid in allPIDs { kill(pid, SIGTERM) }
+        usleep(300_000) // 300ms grace period
+        // SIGKILL anyone still alive.
+        for pid in allPIDs {
+            if Self.isPIDAlive(pid) { kill(pid, SIGKILL) }
+        }
+
+        for (_, continuation) in pendingRequests {
+            continuation.resume(throwing: CodexAppServerError.serverDied)
+        }
+        for (_, continuation) in threadTurnContinuations {
+            continuation.resume(throwing: CodexAppServerError.serverDied)
+        }
+        pendingRequests.removeAll()
+        threadTurnContinuations.removeAll()
+        threadEventHandlers.removeAll()
+        threadRunning.removeAll()
+        activeTurnIDs.removeAll()
+
+        process = nil
+        stdinHandle = nil
+        stdoutHandle = nil
+        stderrHandle = nil
+    }
+
+    /// Returns every descendant PID of the given root, traversing the live
+    /// `ps -axo pid,ppid` table. Synchronous — safe to call from
+    /// applicationWillTerminate.
+    private static func descendantPIDs(of root: Int32) -> [Int32] {
+        // Build pid → [child pids] map from `ps`
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/ps")
+        task.arguments = ["-axo", "pid=,ppid="]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+        do { try task.run() } catch { return [] }
+        task.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let s = String(data: data, encoding: .utf8) else { return [] }
+
+        var children: [Int32: [Int32]] = [:]
+        for line in s.split(separator: "\n") {
+            let fields = line.split(separator: " ", omittingEmptySubsequences: true)
+            guard fields.count >= 2,
+                  let pid = Int32(fields[0]),
+                  let ppid = Int32(fields[1]) else { continue }
+            children[ppid, default: []].append(pid)
+        }
+
+        // BFS from root to collect all descendants.
+        var collected: [Int32] = []
+        var queue: [Int32] = children[root] ?? []
+        while !queue.isEmpty {
+            let pid = queue.removeFirst()
+            collected.append(pid)
+            if let kids = children[pid] { queue.append(contentsOf: kids) }
+        }
+        return collected
+    }
+
+    private static func isPIDAlive(_ pid: Int32) -> Bool {
+        // kill(pid, 0) returns 0 if the process exists and we can signal it.
+        return kill(pid, 0) == 0
+    }
+
+    // MARK: - Lifecycle
+
+    private static func findBinaryPath() -> String? {
+        let candidates = [
+            "\(NSHomeDirectory())/.local/bin/codex-clicky",
+            "/opt/homebrew/bin/codex",
+            "/usr/local/bin/codex",
+        ]
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    /// Idempotent — first caller starts the server and runs `initialize`,
+    /// subsequent callers wait on the same task.
+    private func ensureInitialized() async throws {
+        if isInitialized { return }
+        if let existing = initializeTask {
+            try await existing.value
+            return
+        }
+        let task = Task<Void, Error> {
+            try self.launchProcess()
+            try await self.runInitializeHandshake()
+            self.isInitialized = true
+        }
+        initializeTask = task
+        do {
+            try await task.value
+        } catch {
+            initializeTask = nil
+            throw error
+        }
+    }
+
+    private func launchProcess() throws {
+        guard let binaryPath = Self.findBinaryPath() else {
+            throw CodexAppServerError.binaryNotFound
+        }
+
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        p.arguments = [
+            "-lc",
+            Self.parentWatchdogWrapperScript,
+            "codex-app-server-watchdog",
+            binaryPath,
+            String(ProcessInfo.processInfo.processIdentifier),
+            "app-server",
+            "--listen",
+            "stdio://"
+        ]
+
+        var env = ProcessInfo.processInfo.environment
+        let extraPaths = "\(NSHomeDirectory())/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+        env["PATH"] = extraPaths + ":" + (env["PATH"] ?? "/usr/bin:/bin")
+        env["CODEX_HOME"] = "\(NSHomeDirectory())/.codex"
+        p.environment = env
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        p.standardInput = stdin
+        p.standardOutput = stdout
+        p.standardError = stderr
+
+        // Handle server crash or watchdog cleanup — clear state so next call relaunches.
+        p.terminationHandler = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                print("🟥 codex app-server exited (cleanup)")
+                self.process = nil
+                self.stdinHandle = nil
+                self.stdoutHandle = nil
+                self.stderrHandle = nil
+                self.isInitialized = false
+                self.initializeTask = nil
+                // Fail any pending requests
+                for (_, cont) in self.pendingRequests {
+                    cont.resume(throwing: CodexAppServerError.serverDied)
+                }
+                for (_, cont) in self.threadTurnContinuations {
+                    cont.resume(throwing: CodexAppServerError.serverDied)
+                }
+                self.pendingRequests.removeAll()
+                self.threadTurnContinuations.removeAll()
+                self.threadEventHandlers.removeAll()
+                self.threadRunning.removeAll()
+                self.activeTurnIDs.removeAll()
+            }
+        }
+
+        do {
+            try p.run()
+        } catch {
+            throw CodexAppServerError.processLaunchFailed(error)
+        }
+
+        process = p
+        stdinHandle = stdin.fileHandleForWriting
+        stdoutHandle = stdout.fileHandleForReading
+        stderrHandle = stderr.fileHandleForReading
+
+        // Continuously read stdout — JSON-RPC frames are newline-delimited.
+        stdout.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+            Task { @MainActor [weak self] in
+                self?.handleStdoutChunk(chunk)
+            }
+        }
+
+        // stderr → console for debugging server issues
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
+            let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                print("🟥 codex app-server stderr: \(trimmed)")
+            }
+        }
+
+        print("🚀 codex app-server launched (pid \(p.processIdentifier))")
+    }
+
+    private func runInitializeHandshake() async throws {
+        let params: [String: Any] = [
+            "clientInfo": ["name": "clicky", "version": "1.0"]
+        ]
+        _ = try await sendRequest(method: "initialize", params: params)
+        try sendNotification(method: "initialized")
+        print("🤝 codex app-server initialized")
+    }
+
+    // MARK: - JSON-RPC framing
+
+    /// Sends a request and waits for its matched response.
+    private func sendRequest(method: String, params: [String: Any]) async throws -> [String: Any] {
+        let id = nextRequestID
+        nextRequestID += 1
+        let frame: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        ]
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[String: Any], Error>) in
+            pendingRequests[id] = continuation
+            do {
+                try writeFrame(frame)
+            } catch {
+                pendingRequests.removeValue(forKey: id)
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    private func sendNotification(method: String, params: [String: Any] = [:]) throws {
+        try writeFrame([
+            "method": method,
+            "params": params,
+        ])
+    }
+
+    /// Runs codex under a tiny shell watchdog. Xcode's Stop button can kill the
+    /// Clicky app without delivering normal app-termination notifications, so
+    /// `shutdownSync()` never gets a chance to run. This wrapper keeps a small
+    /// parent-PID monitor alive next to codex; if the Clicky PID disappears, it
+    /// kills the codex app-server subtree and exits.
+    private static let parentWatchdogWrapperScript = #"""
+codex_bin="$1"
+parent_pid="$2"
+shift 2
+
+kill_tree() {
+  local target="$1"
+  local signal="$2"
+  for child in $(/usr/bin/pgrep -P "$target" 2>/dev/null); do
+    kill_tree "$child" "$signal"
+  done
+  /bin/kill "$signal" "$target" 2>/dev/null
+}
+
+"$codex_bin" "$@" &
+codex_pid="$!"
+
+(
+  while /bin/kill -0 "$parent_pid" 2>/dev/null; do
+    /bin/sleep 0.5
+  done
+  kill_tree "$codex_pid" -TERM
+  /bin/sleep 0.5
+  kill_tree "$codex_pid" -KILL
+) &
+watchdog_pid="$!"
+
+wait "$codex_pid"
+status="$?"
+/bin/kill "$watchdog_pid" 2>/dev/null
+exit "$status"
+"""#
+
+    private func writeFrame(_ frame: [String: Any]) throws {
+        guard let stdin = stdinHandle else {
+            throw CodexAppServerError.serverDied
+        }
+        let json = try JSONSerialization.data(withJSONObject: frame, options: [])
+        var line = json
+        line.append(0x0A) // newline terminator
+        try stdin.write(contentsOf: line)
+    }
+
+    /// Parse newline-delimited JSON-RPC frames from accumulating stdout chunks.
+    private func handleStdoutChunk(_ chunk: String) {
+        stdoutBuffer += chunk
+        while let newlineIndex = stdoutBuffer.firstIndex(of: "\n") {
+            let line = String(stdoutBuffer[stdoutBuffer.startIndex..<newlineIndex])
+            stdoutBuffer = String(stdoutBuffer[stdoutBuffer.index(after: newlineIndex)...])
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  let data = trimmed.data(using: .utf8),
+                  let frame = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { continue }
+            handleFrame(frame)
+        }
+    }
+
+    private func handleFrame(_ frame: [String: Any]) {
+        // Response (has `id` and either `result` or `error`)
+        if let id = frame["id"] as? Int,
+           let cont = pendingRequests.removeValue(forKey: id) {
+            if let error = frame["error"] as? [String: Any] {
+                let code = error["code"] as? Int ?? -1
+                let message = error["message"] as? String ?? "unknown"
+                cont.resume(throwing: CodexAppServerError.rpcError(code: code, message: message))
+            } else if let result = frame["result"] as? [String: Any] {
+                cont.resume(returning: result)
+            } else {
+                cont.resume(returning: [:])
+            }
+            return
+        }
+
+        // Notification (has `method`, no matching `id`)
+        guard let method = frame["method"] as? String else { return }
+        let params = frame["params"] as? [String: Any] ?? [:]
+        handleNotification(method: method, params: params)
+    }
+
+    private func handleNotification(method: String, params: [String: Any]) {
+        // Most thread-bound notifications carry a top-level threadId. Route
+        // them to the right per-sibling callback.
+        let threadID = params["threadId"] as? String
+
+        switch method {
+        case "item/agentMessage/delta":
+            // {threadId, turnId, itemId, delta}
+            if let tid = threadID,
+               let handler = threadEventHandlers[tid],
+               let delta = params["delta"] as? String {
+                handler(.agentMessageDelta(delta))
+            }
+
+        case "turn/started":
+            // {threadId, turn: {id, status, ...}}
+            if let tid = threadID,
+               let turn = params["turn"] as? [String: Any],
+               let turnID = turn["id"] as? String {
+                activeTurnIDs[tid] = turnID
+                threadRunning[tid] = true
+            }
+
+        case "item/completed":
+            // {threadId, turnId, item: {type, ...}}
+            guard let tid = threadID,
+                  let handler = threadEventHandlers[tid],
+                  let item = params["item"] as? [String: Any] else { return }
+            let itemType = (item["type"] as? String) ?? ""
+            switch itemType {
+            case "agentMessage", "agent_message", "message":
+                let text = (item["text"] as? String)
+                    ?? extractTextBlocks(from: item["content"])
+                if !text.isEmpty {
+                    handler(.agentMessageComplete(text))
+                }
+            case "commandExecution", "command_execution", "shell_command":
+                let cmd = (item["command"] as? String)
+                    ?? ((item["command"] as? [String])?.joined(separator: " ") ?? "")
+                let output = (item["aggregatedOutput"] as? String)
+                    ?? (item["aggregated_output"] as? String)
+                if !cmd.isEmpty {
+                    handler(.shellCommand(command: cmd, output: output))
+                }
+            case "fileChange", "file_change":
+                if let changes = item["changes"] as? [[String: Any]] {
+                    let paths = changes.compactMap { $0["path"] as? String }
+                    let kinds = changes.map { change -> String in
+                        if let kind = change["kind"] as? String { return kind }
+                        if let kind = change["kind"] as? [String: Any],
+                           let type = kind["type"] as? String {
+                            return type == "update" ? "edit" : type
+                        }
+                        return "edit"
+                    }
+                    if !paths.isEmpty {
+                        handler(.fileChange(paths: paths, kinds: kinds))
+                    }
+                }
+            default:
+                break
+            }
+
+        case "turn/completed":
+            // Terminal — surface whatever assembled text the turn produced.
+            // The notification body has {threadId, turn: {id, status, ...}}.
+            if let tid = threadID, let handler = threadEventHandlers[tid] {
+                let turn = params["turn"] as? [String: Any]
+                if let turnID = turn?["id"] as? String,
+                   activeTurnIDs[tid] == turnID {
+                    activeTurnIDs.removeValue(forKey: tid)
+                }
+                let status = (turn?["status"] as? String) ?? "completed"
+                if status == "failed" {
+                    let error = turn?["error"] as? [String: Any]
+                    let message = (error?["message"] as? String) ?? "Codex turn failed"
+                    handler(.turnFailed(message: message))
+                } else if status == "interrupted" {
+                    handler(.turnFailed(message: "Codex turn was interrupted."))
+                } else {
+                    handler(.turnCompleted(finalText: ""))
+                }
+            }
+
+        case "turn/failed", "error":
+            if let tid = threadID, let handler = threadEventHandlers[tid] {
+                let message = (params["message"] as? String)
+                    ?? ((params["error"] as? [String: Any])?["message"] as? String)
+                    ?? "Codex turn failed"
+                handler(.turnFailed(message: message))
+            }
+
+        default:
+            // Useful for diagnosis: thread/started, turn/started,
+            // thread/tokenUsage/updated, account/rateLimits/updated, etc.
+            // Comment in if you need to see notifications you're not handling.
+            // print("📨 codex notification: \(method)")
+            break
+        }
+    }
+
+    private func extractTextBlocks(from content: Any?) -> String {
+        guard let blocks = content as? [[String: Any]] else { return "" }
+        return blocks.compactMap { block -> String? in
+            guard let t = block["type"] as? String,
+                  t == "output_text" || t == "text" else { return nil }
+            return block["text"] as? String
+        }.joined()
+    }
+}

--- a/leanring-buddy/CodexCLIClient.swift
+++ b/leanring-buddy/CodexCLIClient.swift
@@ -1,0 +1,241 @@
+//
+//  CodexCLIClient.swift
+//  leanring-buddy
+//
+//  Runs the Codex CLI (OpenAI's agent runtime, bundled inside /Applications/Clicky.app)
+//  as a subprocess for agent tasks: "build me a website", "create a spreadsheet", etc.
+//  Uses the user's existing Codex subscription — no API key required.
+//
+//  Routing: CompanionManager routes transcripts that start with "codex" here.
+//  Everything else goes to ClaudeCodeCLIClient (voice responses).
+//
+
+import Foundation
+
+enum CodexCLIError: Error, LocalizedError {
+    case binaryNotFound
+    case processLaunchFailed(Error)
+    case noResponseReceived
+    case agentError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .binaryNotFound:
+            return "Codex CLI not found. Make sure /Applications/Clicky.app is installed."
+        case .processLaunchFailed(let underlying):
+            return "Failed to launch Codex CLI: \(underlying.localizedDescription)"
+        case .noResponseReceived:
+            return "Codex exited without producing a response."
+        case .agentError(let message):
+            return "Codex agent error: \(message)"
+        }
+    }
+}
+
+/// Runs agent tasks using the Codex CLI bundled in /Applications/Clicky.app.
+/// Uses the Codex subscription stored at ~/.codex/auth.json — no API key needed.
+final class CodexCLIClient {
+    /// Saved copy of the newer Codex binary (v0.124.0, supports gpt-5.5 subscription mode).
+    private static let savedCodexBinaryPath = "\(NSHomeDirectory())/.local/bin/codex-clicky"
+    private static let homebrewCodexBinaryPath = "/opt/homebrew/bin/codex"
+
+    static func findBinaryPath() -> String? {
+        // Prefer the saved binary — it's v0.124.0 with gpt-5.5 subscription support.
+        // Fall back to the Homebrew install.
+        if FileManager.default.isExecutableFile(atPath: savedCodexBinaryPath) {
+            return savedCodexBinaryPath
+        }
+        if FileManager.default.isExecutableFile(atPath: homebrewCodexBinaryPath) {
+            return homebrewCodexBinaryPath
+        }
+        return nil
+    }
+
+    static func isAvailable() -> Bool {
+        findBinaryPath() != nil
+    }
+
+    /// Returns true if the transcript looks like an agent task that Codex should handle.
+    /// Primary trigger: "clicky agent" (as shown at heyclicky.com).
+    /// Secondary triggers: explicit "codex" prefix or strong action phrases.
+    static func isAgentTask(_ transcript: String) -> Bool {
+        let lower = transcript.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        let agentTriggers = [
+            // Primary trigger — the official way to invoke agent mode
+            "clicky agent",
+            "hey clicky agent",
+            // Explicit codex invocations
+            "codex ",
+            "codex,",
+            "hey codex",
+            // Strong action phrases that imply an autonomous task
+            "build me",
+            "create a ",
+            "make me a",
+            "write a script",
+            "write a program",
+            "generate a ",
+            "set up a",
+            "browse to",
+            "search the web",
+        ]
+        return agentTriggers.contains { lower.hasPrefix($0) }
+    }
+
+    /// Runs a Codex agent task non-interactively.
+    ///
+    /// - Parameters:
+    ///   - prompt: The task description spoken by the user.
+    ///   - screenshots: Screen captures to provide context to the agent.
+    ///   - memoryContextBlock: Optional memory context to prepend to the prompt.
+    ///   - workingDirectory: Directory the agent will use as its workspace. Defaults to ~/Desktop.
+    ///   - onProgressChunk: Called on MainActor with accumulated text as the agent streams output.
+    /// - Returns: The final agent response text.
+    func runAgentTask(
+        prompt: String,
+        screenshots: [(data: Data, label: String)],
+        memoryContextBlock: String = "",
+        workingDirectory: String? = nil,
+        onProgressChunk: @escaping @MainActor @Sendable (String) -> Void
+    ) async throws -> String {
+        guard let binaryPath = Self.findBinaryPath() else {
+            throw CodexCLIError.binaryNotFound
+        }
+
+        // Write screenshots to temp files — codex exec takes image paths, not base64
+        let tempDir = FileManager.default.temporaryDirectory
+        var screenshotFilePaths: [String] = []
+        defer {
+            // Clean up temp screenshot files after the process exits
+            for path in screenshotFilePaths {
+                try? FileManager.default.removeItem(atPath: path)
+            }
+        }
+
+        for (index, screenshot) in screenshots.enumerated() {
+            let tempPath = tempDir
+                .appendingPathComponent("clicky_codex_screen_\(index)_\(UUID().uuidString).jpg")
+                .path
+            try screenshot.data.write(to: URL(fileURLWithPath: tempPath))
+            screenshotFilePaths.append(tempPath)
+        }
+
+        // Prepend memory context so the agent has session awareness
+        let fullPrompt: String = {
+            if memoryContextBlock.isEmpty { return prompt }
+            return "\(memoryContextBlock)\n\n\(prompt)"
+        }()
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+
+        var arguments = ["exec", "--json", "--skip-git-repo-check"]
+        for screenshotPath in screenshotFilePaths {
+            arguments += ["-i", screenshotPath]
+        }
+        // Working directory defaults to ~/Desktop so created files land somewhere visible
+        let workspace = workingDirectory ?? "\(NSHomeDirectory())/Desktop"
+        arguments += ["-C", workspace]
+        arguments.append(fullPrompt)
+
+        process.arguments = arguments
+
+        // Ensure the binary finds its dependencies regardless of the macOS app sandbox PATH
+        var env = ProcessInfo.processInfo.environment
+        let extraPaths = "\(NSHomeDirectory())/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+        env["PATH"] = extraPaths + ":" + (env["PATH"] ?? "/usr/bin:/bin")
+        // Use the standard CODEX_HOME so existing auth.json and memories are picked up
+        env["CODEX_HOME"] = "\(NSHomeDirectory())/.codex"
+        process.environment = env
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            throw CodexCLIError.processLaunchFailed(error)
+        }
+
+        print("🤖 Codex agent started for task: \(prompt.prefix(80))...")
+
+        return try await withCheckedThrowingContinuation { continuation in
+            var resumed = false
+            var accumulatedResponseText = ""
+            var lineBuffer = ""
+
+            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+                lineBuffer += chunk
+
+                // Each JSONL event is newline-terminated
+                while let newlineIndex = lineBuffer.firstIndex(of: "\n") {
+                    let line = String(lineBuffer[lineBuffer.startIndex..<newlineIndex])
+                    lineBuffer = String(lineBuffer[lineBuffer.index(after: newlineIndex)...])
+
+                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty,
+                          let eventData = trimmed.data(using: .utf8),
+                          let event = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
+                          let eventType = event["type"] as? String
+                    else { continue }
+
+                    // Streaming text deltas — Codex streams partial output as it works
+                    if (eventType == "output_text.delta" || eventType == "response.output_text.delta"),
+                       let delta = event["delta"] as? String, !delta.isEmpty {
+                        accumulatedResponseText += delta
+                        let snapshot = accumulatedResponseText
+                        Task { @MainActor in await onProgressChunk(snapshot) }
+                    }
+
+                    // Completed message item — the final text for a turn
+                    if eventType == "item.completed",
+                       let item = event["item"] as? [String: Any],
+                       (item["type"] as? String) == "message",
+                       let contentArray = item["content"] as? [[String: Any]] {
+                        let completedText = contentArray.compactMap { block -> String? in
+                            guard let blockType = block["type"] as? String,
+                                  blockType == "output_text" || blockType == "text" else { return nil }
+                            return block["text"] as? String
+                        }.joined()
+                        if !completedText.isEmpty {
+                            accumulatedResponseText = completedText
+                            let snapshot = accumulatedResponseText
+                            Task { @MainActor in await onProgressChunk(snapshot) }
+                        }
+                    }
+
+                    // Error events — surface as thrown errors so CompanionManager can respond gracefully
+                    if eventType == "error" || eventType == "turn.failed" {
+                        let errorMessage: String = {
+                            if let msg = event["message"] as? String { return msg }
+                            if let errObj = event["error"] as? [String: Any],
+                               let msg = errObj["message"] as? String { return msg }
+                            return "Unknown Codex error"
+                        }()
+                        if !resumed {
+                            resumed = true
+                            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                            continuation.resume(throwing: CodexCLIError.agentError(errorMessage))
+                        }
+                    }
+                }
+            }
+
+            process.terminationHandler = { _ in
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                guard !resumed else { return }
+                resumed = true
+
+                if accumulatedResponseText.isEmpty {
+                    continuation.resume(throwing: CodexCLIError.noResponseReceived)
+                } else {
+                    continuation.resume(returning: accumulatedResponseText)
+                }
+            }
+        }
+    }
+}

--- a/leanring-buddy/CodexCLIClient.swift
+++ b/leanring-buddy/CodexCLIClient.swift
@@ -56,19 +56,51 @@ final class CodexCLIClient {
     }
 
     /// Returns true if the transcript looks like an agent task that Codex should handle.
-    /// Primary trigger: "clicky agent" (as shown at heyclicky.com).
-    /// Secondary triggers: explicit "codex" prefix or strong action phrases.
+    ///
+    /// Detection is lenient because AssemblyAI sometimes mishears "Clicky" as
+    /// "Learning Buddy" / "leaning buddy" / "clicker" / etc. Rules:
+    ///   1. If the wake word "agent" appears in the first 6 words of the transcript,
+    ///      it's an agent task (covers "Clicky agent ...", "Learning Buddy agent ...",
+    ///      "Hey Clicky, agent build me ...", etc.).
+    ///   2. Explicit "codex ..." invocations always route to the agent.
+    ///   3. Strong autonomous-action prefixes ("build me a ...", "create a ...", etc.)
+    ///      route to the agent.
     static func isAgentTask(_ transcript: String) -> Bool {
         let lower = transcript.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Rule 1 — wake word "agent" / "agents" / "codex" near the start of
+        // the transcript (broadened to first 8 words to tolerate filler like
+        // "uh, start another...").
+        let firstWords = lower
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .prefix(8)
+        if firstWords.contains("agent") || firstWords.contains("agents") || firstWords.contains("codex") {
+            return true
+        }
+
+        // Rule 1b — any-position phrases that clearly intend an agent task.
+        // Catches "start another Codex session", "fork an agent", "spawn a
+        // new session", etc., even when they don't begin the sentence.
+        let agentContextPhrases = [
+            "codex session", "codex agent", "codex sessions", "codex agents",
+            "another codex", "another agent", "another session",
+            "new codex", "new agent",
+            "spawn an agent", "spawn agent",
+            "fire up an agent", "fire up a codex",
+            "launch an agent", "launch a codex",
+            "start an agent", "start a codex",
+            "fork an agent", "fork a codex",
+        ]
+        if agentContextPhrases.contains(where: { lower.contains($0) }) {
+            return true
+        }
+
+        // Rules 2 & 3 — explicit invocations and action prefixes.
         let agentTriggers = [
-            // Primary trigger — the official way to invoke agent mode
-            "clicky agent",
-            "hey clicky agent",
-            // Explicit codex invocations
             "codex ",
             "codex,",
             "hey codex",
-            // Strong action phrases that imply an autonomous task
             "build me",
             "create a ",
             "make me a",
@@ -78,8 +110,187 @@ final class CodexCLIClient {
             "set up a",
             "browse to",
             "search the web",
+            "spawn ",
+            "launch a codex",
         ]
         return agentTriggers.contains { lower.hasPrefix($0) }
+    }
+
+    /// Splits a transcript into N parallel task strings when the user explicitly
+    /// asked for multiple sessions / agents. Returns [transcript] for single-task
+    /// requests so existing single-agent flows are unchanged.
+    ///
+    /// Examples:
+    ///   "agent, spawn two sessions, one for X and one for Y" → ["X", "Y"]
+    ///   "build me three sessions, one for A, one for B, one for C" → ["A", "B", "C"]
+    ///   "agent, build me a snake game"  → unchanged (single task)
+    static func decomposeTaskIntoParallelTasks(_ transcript: String) -> [String] {
+        let lower = transcript.lowercased()
+
+        // Only consider splitting if the user explicitly mentioned multiple sessions / agents.
+        // This avoids splitting "build me a calculator and a button" into two unrelated tasks.
+        let multiSessionMarkers = [
+            "spawn ",
+            "parallel",
+            "in parallel",
+            "two sessions", "three sessions", "four sessions", "five sessions",
+            "two agents", "three agents", "four agents", "five agents",
+            "multiple agents", "multiple sessions",
+            "siblings",
+            "one for",
+            "one to",
+        ]
+        let isMultiSession = multiSessionMarkers.contains { lower.contains($0) }
+        guard isMultiSession else { return [transcript] }
+
+        // Split on enumeration markers people say in natural English when
+        // listing parallel tasks. Matches a marker followed by EITHER:
+        //   • required "to" / "for"  ("one to X", "first for X")
+        //   • OR explicit punctuation comma/period/colon/paren ("1,", "2.")
+        // The punctuation case lets us split "2, how to go..." (where "how"
+        // is between marker and "to") without false-matching "2 dogs".
+        //
+        // Markers (qualified-noun form requires a qualifier; plain "one"
+        // and digits are allowed bare; "agent"/"session"/"task" alone are
+        // NOT, to avoid matching "the agent" etc.):
+        //   • one
+        //   • the other (one|agent|session|task)
+        //   • another (one|agent|session|task)
+        //   • (first|second|third|fourth|fifth) [(one|agent|session|task)]
+        //   • [1-9]
+        //
+        // After the marker, allow ONE optional helper verb between the
+        // marker and "to"/"for". Catches:
+        //   "the other one IS to make X"
+        //   "another one WILL TO do X"
+        //   "second one NEEDS to find X"
+        let collapsedSplitPattern = #"\b(?:(?:(?:the\s+)?other\s+|another\s+)(?:one|agent|session|task)|one|(?:first|second|third|fourth|fifth)(?:\s+(?:one|agent|session|task))?|[1-9])\b(?:[,.):]\s*(?:(?:to|for)\b\s*)?|\s+(?:(?:is|was|are|were|will|would|should|shall|needs?|has|have|had|can|could|may|might|must|just)\s+)?(?:to|for)\b\s*)"#
+        // Use a sentinel that won't appear in spoken transcripts.
+        let splitSentinel = "\u{FFFC}"
+        let normalized = transcript.replacingOccurrences(
+            of: collapsedSplitPattern,
+            with: splitSentinel,
+            options: [.regularExpression, .caseInsensitive]
+        )
+
+        if normalized.contains(splitSentinel) {
+            let parts = normalized
+                .components(separatedBy: splitSentinel)
+                .dropFirst() // discard preamble before the first "one for"
+                .map { rawTask -> String in
+                    var cleaned = rawTask.trimmingCharacters(in: CharacterSet(charactersIn: " ,.?;:!"))
+                    // Strip trailing connectors like "and" or "and then"
+                    let trailingConnectors = [" and then", " and"]
+                    for connector in trailingConnectors {
+                        if cleaned.lowercased().hasSuffix(connector) {
+                            cleaned = String(cleaned.dropLast(connector.count))
+                        }
+                    }
+                    // Strip leading filler like "um," / "uh,"
+                    let leadingFillers = ["um,", "um ", "uh,", "uh "]
+                    for filler in leadingFillers {
+                        if cleaned.lowercased().hasPrefix(filler) {
+                            cleaned = String(cleaned.dropFirst(filler.count))
+                        }
+                    }
+                    return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                .filter { !$0.isEmpty }
+            if parts.count >= 2 {
+                return Array(parts)
+            }
+        }
+
+        return [transcript]
+    }
+
+    /// Returns the parallel task list for a transcript. First tries the fast
+    /// regex split. If that returns 1 task but the transcript clearly asked
+    /// for multiple sessions, falls back to a Haiku call to decompose the
+    /// natural-language list into N tasks. ~2-3s for the LLM fallback.
+    static func decomposeTaskIntoParallelTasksWithLLMFallback(_ transcript: String) async -> [String] {
+        // Fast path — regex
+        let regexTasks = decomposeTaskIntoParallelTasks(transcript)
+        if regexTasks.count >= 2 { return regexTasks }
+
+        // Did the user explicitly ask for multiple sessions? If not, don't
+        // bother burning an LLM call — single-task requests should stay fast.
+        let lower = transcript.lowercased()
+        let multiSessionMarkers = [
+            "spawn ", "parallel", "in parallel",
+            "two sessions", "three sessions", "two agents", "three agents",
+            "multiple agents", "multiple sessions", "siblings",
+            "second agent", "second session",
+            "another agent", "another session",
+            "two codex", "three codex",
+        ]
+        let isMultiSession = multiSessionMarkers.contains { lower.contains($0) }
+        guard isMultiSession else { return regexTasks }
+
+        // LLM fallback — only fires if regex couldn't split AND user clearly
+        // asked for multiple agents. Reliable across any phrasing.
+        guard ClaudeCodeCLIClient.isAvailable() else {
+            print("🤖 Decompose: LLM fallback unavailable (no Claude CLI), keeping single task")
+            return regexTasks
+        }
+
+        let client = ClaudeCodeCLIClient(model: "claude-haiku-4-5-20251001")
+        let systemPrompt = "You decompose user requests into a list of parallel tasks. Reply with valid JSON only, no markdown fences, no prose."
+        let prompt = """
+        The user asked an AI assistant to spawn multiple parallel agents. Split this spoken transcript into the individual tasks each agent should do.
+
+        Transcript:
+        \(transcript)
+
+        Rules:
+        - Return ONLY the actions each agent should perform, in plain English.
+        - Strip filler ("uh", "um", "you know"), wake words ("hey clicky", "agent"), meta instructions ("spawn two agents", "make sure they're separate sessions").
+        - Each task is a standalone, complete instruction.
+        - If the transcript actually only contains one task, return it as-is.
+
+        Examples:
+        Input: "spawn two agents, one to research market for Clicky, and the other one is to make a landing page"
+        Output: {"tasks": ["research market for Clicky", "make a landing page"]}
+
+        Input: "Start 2 Codex sessions, one to research the prospects for a product like Clicky. And the other one is to make a simple landing page."
+        Output: {"tasks": ["research prospects for a product like Clicky", "make a simple landing page"]}
+
+        Input: "agent, build me a snake game"
+        Output: {"tasks": ["build me a snake game"]}
+
+        Return ONLY the JSON object:
+        """
+
+        print("🤖 Decompose: regex returned 1 task, calling Haiku for LLM decomposition")
+        do {
+            let (response, _) = try await client.analyzeImageStreaming(
+                images: [],
+                systemPrompt: systemPrompt,
+                conversationHistory: [],
+                userPrompt: prompt,
+                onTextChunk: { _ in }
+            )
+
+            // Strip any leading/trailing chatter — keep just the JSON object
+            guard let jsonStart = response.firstIndex(of: "{"),
+                  let jsonEnd = response.lastIndex(of: "}"),
+                  jsonStart < jsonEnd else {
+                print("🤖 Decompose: LLM response had no JSON, keeping regex result")
+                return regexTasks
+            }
+            let jsonStr = String(response[jsonStart...jsonEnd])
+            guard let data = jsonStr.data(using: .utf8),
+                  let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let tasks = parsed["tasks"] as? [String], !tasks.isEmpty else {
+                print("🤖 Decompose: LLM JSON parse failed, keeping regex result")
+                return regexTasks
+            }
+            print("🤖 Decompose: LLM returned \(tasks.count) task(s)")
+            return tasks
+        } catch {
+            print("🤖 Decompose: LLM call failed: \(error.localizedDescription)")
+            return regexTasks
+        }
     }
 
     /// Runs a Codex agent task non-interactively.
@@ -96,7 +307,9 @@ final class CodexCLIClient {
         screenshots: [(data: Data, label: String)],
         memoryContextBlock: String = "",
         workingDirectory: String? = nil,
-        onProgressChunk: @escaping @MainActor @Sendable (String) -> Void
+        onProgressChunk: @escaping @MainActor @Sendable (String) -> Void,
+        onThreadStarted: @escaping @MainActor @Sendable (String) -> Void = { _ in },
+        onProcessStarted: @escaping @MainActor @Sendable (Process) -> Void = { _ in }
     ) async throws -> String {
         guard let binaryPath = Self.findBinaryPath() else {
             throw CodexCLIError.binaryNotFound
@@ -129,12 +342,25 @@ final class CodexCLIClient {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: binaryPath)
 
-        var arguments = ["exec", "--json", "--skip-git-repo-check"]
+        // --full-auto: workspace-write sandbox + auto-approve. Without this
+        // codex runs in read-only mode and can't create files, breaking any
+        // "build me X" prompt. workspace-write scopes the agent's reads and
+        // writes to the working directory, so a contained workspace below
+        // keeps Codex out of the rest of the user's filesystem.
+        var arguments = ["exec", "--json", "--skip-git-repo-check", "--full-auto"]
         for screenshotPath in screenshotFilePaths {
             arguments += ["-i", screenshotPath]
         }
-        // Working directory defaults to ~/Desktop so created files land somewhere visible
-        let workspace = workingDirectory ?? "\(NSHomeDirectory())/Desktop"
+        // PRIVACY: Default workspace is ~/Desktop/clicky-agents (not ~/Desktop
+        // itself) so Codex's workspace-write sandbox can't list or read the
+        // rest of the user's Desktop. Created files land in a clearly-labelled
+        // subfolder the user can find and clean up.
+        let defaultWorkspace = "\(NSHomeDirectory())/Desktop/clicky-agents"
+        let workspace = workingDirectory ?? defaultWorkspace
+        try? FileManager.default.createDirectory(
+            atPath: workspace,
+            withIntermediateDirectories: true
+        )
         arguments += ["-C", workspace]
         arguments.append(fullPrompt)
 
@@ -150,21 +376,39 @@ final class CodexCLIClient {
 
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
+        let stdinPipe = Pipe()
+        process.standardInput = stdinPipe
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
         do {
             try process.run()
+            try? stdinPipe.fileHandleForWriting.close()
         } catch {
+            try? stdinPipe.fileHandleForWriting.close()
             throw CodexCLIError.processLaunchFailed(error)
         }
 
         print("🤖 Codex agent started for task: \(prompt.prefix(80))...")
+        let runningProcess = process
+        Task { @MainActor in onProcessStarted(runningProcess) }
 
         return try await withCheckedThrowingContinuation { continuation in
             var resumed = false
             var accumulatedResponseText = ""
             var lineBuffer = ""
+            var stderrBuffer = ""
+
+            // Capture stderr so we can surface real codex error messages when
+            // the subprocess exits without producing usable JSONL on stdout.
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+                stderrBuffer += chunk
+                // Echo stderr to Xcode console too so the developer can see
+                // codex errors live during a session.
+                print("🟥 codex stderr: \(chunk.trimmingCharacters(in: .whitespacesAndNewlines))")
+            }
 
             stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
@@ -183,6 +427,13 @@ final class CodexCLIClient {
                           let eventType = event["type"] as? String
                     else { continue }
 
+                    // thread.started — emit the codex thread/session ID so the
+                    // session can be resumed later for follow-up messages.
+                    if eventType == "thread.started",
+                       let threadID = event["thread_id"] as? String, !threadID.isEmpty {
+                        Task { @MainActor in await onThreadStarted(threadID) }
+                    }
+
                     // Streaming text deltas — Codex streams partial output as it works
                     if (eventType == "output_text.delta" || eventType == "response.output_text.delta"),
                        let delta = event["delta"] as? String, !delta.isEmpty {
@@ -191,18 +442,88 @@ final class CodexCLIClient {
                         Task { @MainActor in await onProgressChunk(snapshot) }
                     }
 
-                    // Completed message item — the final text for a turn
+                    // Completed item — codex emits these for agent messages,
+                    // tool calls (shell commands, file edits), and reasoning.
+                    // We surface them all so the panel shows what the agent
+                    // is doing in real time.
                     if eventType == "item.completed",
-                       let item = event["item"] as? [String: Any],
-                       (item["type"] as? String) == "message",
-                       let contentArray = item["content"] as? [[String: Any]] {
-                        let completedText = contentArray.compactMap { block -> String? in
-                            guard let blockType = block["type"] as? String,
-                                  blockType == "output_text" || blockType == "text" else { return nil }
-                            return block["text"] as? String
-                        }.joined()
-                        if !completedText.isEmpty {
-                            accumulatedResponseText = completedText
+                       let item = event["item"] as? [String: Any] {
+                        let itemType = item["type"] as? String ?? ""
+                        var renderedText: String?
+
+                        switch itemType {
+                        case "agent_message", "message":
+                            // New shape: item.text directly (codex >= 0.124).
+                            // Old shape: item.content[].text (legacy).
+                            if let text = item["text"] as? String, !text.isEmpty {
+                                renderedText = text
+                            } else if let contentArray = item["content"] as? [[String: Any]] {
+                                let joined = contentArray.compactMap { block -> String? in
+                                    guard let blockType = block["type"] as? String,
+                                          blockType == "output_text" || blockType == "text" else { return nil }
+                                    return block["text"] as? String
+                                }.joined()
+                                if !joined.isEmpty { renderedText = joined }
+                            }
+
+                        case "command_execution", "shell_command":
+                            // Tool call running a shell command — show the
+                            // command and any aggregated stdout so the user
+                            // sees what codex is doing in real time.
+                            let cmd: String? = {
+                                if let s = item["command"] as? String { return s }
+                                if let arr = item["command"] as? [String] { return arr.joined(separator: " ") }
+                                return nil
+                            }()
+                            if let cmd {
+                                var text = "$ \(cmd)"
+                                if let output = item["aggregated_output"] as? String,
+                                   !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                    text += "\n" + output.trimmingCharacters(in: .whitespacesAndNewlines)
+                                }
+                                renderedText = text
+                            }
+
+                        case "file_change", "edit", "patch":
+                            // Codex emits {path, kind} entries inside `changes`.
+                            // Older builds emitted top-level `path`. Handle both.
+                            if let changes = item["changes"] as? [[String: Any]] {
+                                let lines = changes.compactMap { change -> String? in
+                                    guard let path = change["path"] as? String else { return nil }
+                                    let kind = (change["kind"] as? String) ?? "edit"
+                                    let icon: String = {
+                                        switch kind {
+                                        case "add": return "+"
+                                        case "delete": return "−"
+                                        default: return "✎"
+                                        }
+                                    }()
+                                    return "\(icon) \(path)"
+                                }
+                                if !lines.isEmpty {
+                                    renderedText = lines.joined(separator: "\n")
+                                }
+                            } else if let path = item["path"] as? String {
+                                renderedText = "✎ \(path)"
+                            }
+
+                        case "reasoning":
+                            // Skip reasoning items — too noisy
+                            renderedText = nil
+
+                        default:
+                            // Unknown item type — log and surface text if any
+                            if let text = item["text"] as? String, !text.isEmpty {
+                                renderedText = "[\(itemType)] \(text)"
+                            }
+                        }
+
+                        if let text = renderedText {
+                            if accumulatedResponseText.isEmpty {
+                                accumulatedResponseText = text
+                            } else {
+                                accumulatedResponseText += "\n\n" + text
+                            }
                             let snapshot = accumulatedResponseText
                             Task { @MainActor in await onProgressChunk(snapshot) }
                         }
@@ -225,13 +546,207 @@ final class CodexCLIClient {
                 }
             }
 
-            process.terminationHandler = { _ in
+            process.terminationHandler = { terminatedProcess in
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
                 guard !resumed else { return }
                 resumed = true
 
                 if accumulatedResponseText.isEmpty {
-                    continuation.resume(throwing: CodexCLIError.noResponseReceived)
+                    let stderrSnippet = stderrBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let exitCode = terminatedProcess.terminationStatus
+                    if !stderrSnippet.isEmpty {
+                        let detail = String(stderrSnippet.suffix(500))
+                        continuation.resume(throwing: CodexCLIError.agentError("codex exit \(exitCode): \(detail)"))
+                    } else {
+                        continuation.resume(throwing: CodexCLIError.noResponseReceived)
+                    }
+                } else {
+                    continuation.resume(returning: accumulatedResponseText)
+                }
+            }
+        }
+    }
+
+    /// Continues an existing Codex session by ID and sends a follow-up prompt.
+    /// Used when the user types or speaks a follow-up in the detail panel.
+    func runAgentFollowUp(
+        threadID: String,
+        prompt: String,
+        workingDirectory: String? = nil,
+        onProgressChunk: @escaping @MainActor @Sendable (String) -> Void,
+        onProcessStarted: @escaping @MainActor @Sendable (Process) -> Void = { _ in }
+    ) async throws -> String {
+        guard let binaryPath = Self.findBinaryPath() else {
+            throw CodexCLIError.binaryNotFound
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+
+        var arguments = ["exec", "--json", "--skip-git-repo-check", "--full-auto", "resume", threadID]
+        let defaultWorkspace = "\(NSHomeDirectory())/Desktop/clicky-agents"
+        let workspace = workingDirectory ?? defaultWorkspace
+        try? FileManager.default.createDirectory(
+            atPath: workspace,
+            withIntermediateDirectories: true
+        )
+        arguments += ["-C", workspace]
+        arguments.append(prompt)
+        process.arguments = arguments
+
+        var env = ProcessInfo.processInfo.environment
+        let extraPaths = "\(NSHomeDirectory())/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+        env["PATH"] = extraPaths + ":" + (env["PATH"] ?? "/usr/bin:/bin")
+        env["CODEX_HOME"] = "\(NSHomeDirectory())/.codex"
+        process.environment = env
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        let stdinPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+            try? stdinPipe.fileHandleForWriting.close()
+        } catch {
+            try? stdinPipe.fileHandleForWriting.close()
+            throw CodexCLIError.processLaunchFailed(error)
+        }
+
+        print("🔁 Codex follow-up resumed thread \(threadID.prefix(8))… for: \(prompt.prefix(60))")
+        let runningProcess = process
+        Task { @MainActor in onProcessStarted(runningProcess) }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            var resumed = false
+            var accumulatedResponseText = ""
+            var lineBuffer = ""
+            var stderrBuffer = ""
+
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+                stderrBuffer += chunk
+                print("🟥 codex stderr (resume): \(chunk.trimmingCharacters(in: .whitespacesAndNewlines))")
+            }
+
+            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+                lineBuffer += chunk
+
+                while let newlineIndex = lineBuffer.firstIndex(of: "\n") {
+                    let line = String(lineBuffer[lineBuffer.startIndex..<newlineIndex])
+                    lineBuffer = String(lineBuffer[lineBuffer.index(after: newlineIndex)...])
+
+                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty,
+                          let eventData = trimmed.data(using: .utf8),
+                          let event = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
+                          let eventType = event["type"] as? String
+                    else { continue }
+
+                    if (eventType == "output_text.delta" || eventType == "response.output_text.delta"),
+                       let delta = event["delta"] as? String, !delta.isEmpty {
+                        accumulatedResponseText += delta
+                        let snapshot = accumulatedResponseText
+                        Task { @MainActor in await onProgressChunk(snapshot) }
+                    }
+
+                    if eventType == "item.completed",
+                       let item = event["item"] as? [String: Any] {
+                        let itemType = item["type"] as? String ?? ""
+                        var renderedText: String?
+                        switch itemType {
+                        case "agent_message", "message":
+                            if let text = item["text"] as? String, !text.isEmpty {
+                                renderedText = text
+                            } else if let contentArray = item["content"] as? [[String: Any]] {
+                                let joined = contentArray.compactMap { block -> String? in
+                                    guard let blockType = block["type"] as? String,
+                                          blockType == "output_text" || blockType == "text" else { return nil }
+                                    return block["text"] as? String
+                                }.joined()
+                                if !joined.isEmpty { renderedText = joined }
+                            }
+                        case "command_execution", "shell_command":
+                            let cmd: String? = {
+                                if let s = item["command"] as? String { return s }
+                                if let arr = item["command"] as? [String] { return arr.joined(separator: " ") }
+                                return nil
+                            }()
+                            if let cmd {
+                                var text = "$ \(cmd)"
+                                if let output = item["aggregated_output"] as? String,
+                                   !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                    text += "\n" + output.trimmingCharacters(in: .whitespacesAndNewlines)
+                                }
+                                renderedText = text
+                            }
+                        case "file_change", "edit", "patch":
+                            if let changes = item["changes"] as? [[String: Any]] {
+                                let lines = changes.compactMap { change -> String? in
+                                    guard let path = change["path"] as? String else { return nil }
+                                    let kind = (change["kind"] as? String) ?? "edit"
+                                    let icon: String = kind == "add" ? "+" : (kind == "delete" ? "−" : "✎")
+                                    return "\(icon) \(path)"
+                                }
+                                if !lines.isEmpty { renderedText = lines.joined(separator: "\n") }
+                            } else if let path = item["path"] as? String {
+                                renderedText = "✎ \(path)"
+                            }
+                        case "reasoning":
+                            renderedText = nil
+                        default:
+                            if let text = item["text"] as? String, !text.isEmpty {
+                                renderedText = "[\(itemType)] \(text)"
+                            }
+                        }
+                        if let text = renderedText {
+                            if accumulatedResponseText.isEmpty {
+                                accumulatedResponseText = text
+                            } else {
+                                accumulatedResponseText += "\n\n" + text
+                            }
+                            let snapshot = accumulatedResponseText
+                            Task { @MainActor in await onProgressChunk(snapshot) }
+                        }
+                    }
+
+                    if eventType == "error" || eventType == "turn.failed" {
+                        let errorMessage: String = {
+                            if let msg = event["message"] as? String { return msg }
+                            if let errObj = event["error"] as? [String: Any],
+                               let msg = errObj["message"] as? String { return msg }
+                            return "Unknown Codex error"
+                        }()
+                        if !resumed {
+                            resumed = true
+                            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                            stderrPipe.fileHandleForReading.readabilityHandler = nil
+                            continuation.resume(throwing: CodexCLIError.agentError(errorMessage))
+                        }
+                    }
+                }
+            }
+
+            process.terminationHandler = { terminatedProcess in
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                guard !resumed else { return }
+                resumed = true
+                if accumulatedResponseText.isEmpty {
+                    let stderrSnippet = stderrBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let exitCode = terminatedProcess.terminationStatus
+                    if !stderrSnippet.isEmpty {
+                        let detail = String(stderrSnippet.suffix(500))
+                        continuation.resume(throwing: CodexCLIError.agentError("codex exit \(exitCode): \(detail)"))
+                    } else {
+                        continuation.resume(throwing: CodexCLIError.noResponseReceived)
+                    }
                 } else {
                     continuation.resume(returning: accumulatedResponseText)
                 }

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -83,12 +83,28 @@ final class CompanionManager: ObservableObject {
         }
     }()
 
+    /// Codex CLI client for agent tasks ("build me a website", "create a spreadsheet", etc.)
+    /// Uses the bundled Codex runtime from /Applications/Clicky.app with the user's Codex subscription.
+    private let codexCLIClient = CodexCLIClient()
+
+    /// Tracks all running and recently completed Codex agent sessions (the "siblings").
+    let agentSessionManager = AgentSessionManager()
+
+    /// Owns the floating siblings overlay window that shows mini sibling icons.
+    private let agentSiblingsWindowManager = AgentSiblingsWindowManager()
+
+    /// Manages persistent memory across sessions: ~/.clicky/memory.md, user.md, history.json.
+    private let memoryManager = MemoryManager()
+
+    /// Memory context block injected into every system prompt. Loaded at startup from disk.
+    private var memoryCacheSystemPromptBlock: String = ""
+
     private lazy var elevenLabsTTSClient: ElevenLabsTTSClient = {
         return ElevenLabsTTSClient()
     }()
 
     /// Conversation history so Claude remembers prior exchanges within a session.
-    /// Each entry is the user's transcript and Claude's response.
+    /// Seeded from history.json on startup so sessions resume across app restarts.
     private var conversationHistory: [(userTranscript: String, assistantResponse: String)] = []
 
     /// The currently running AI response task, if any. Cancelled when the user
@@ -186,6 +202,24 @@ final class CompanionManager: ObservableObject {
         bindVoiceStateObservation()
         bindAudioPowerLevel()
         bindShortcutTransitions()
+
+        // Load persistent memory and seed conversation history from previous sessions
+        let sessionContext = memoryManager.loadSessionContext()
+        memoryCacheSystemPromptBlock = sessionContext.systemPromptBlock
+        // Seed with up to the last 5 exchanges so the session resumes naturally
+        conversationHistory = sessionContext.seedHistory.suffix(5).map { $0 }
+        print("🧠 Codex CLI available: \(CodexCLIClient.isAvailable())")
+
+        // Save memory when the app quits — runs end-of-session summarization
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.memoryManager.onSessionEnd(fullSessionHistory: self.conversationHistory)
+        }
+
         // Eagerly touch the Claude API so its TLS warmup handshake completes
         // well before the onboarding demo fires at ~40s into the video.
         _ = claudeAPI
@@ -554,6 +588,12 @@ final class CompanionManager: ObservableObject {
 
     // MARK: - Companion Prompt
 
+    /// Builds the system prompt, prepending the memory context block so Clicky
+    /// remembers facts and preferences from previous sessions.
+    private var companionVoiceResponseSystemPromptWithMemory: String {
+        memoryCacheSystemPromptBlock + Self.companionVoiceResponseSystemPrompt
+    }
+
     private static let companionVoiceResponseSystemPrompt = """
     you're clicky, a friendly always-on companion that lives in the user's menu bar. the user just spoke to you via push-to-talk and you can see their screen(s). your reply will be spoken aloud via text-to-speech, so write the way you'd actually talk. this is an ongoing conversation — you remember everything they've said before.
 
@@ -612,6 +652,47 @@ final class CompanionManager: ObservableObject {
 
                 guard !Task.isCancelled else { return }
 
+                // Route to Codex agent for task-oriented requests (build, create, browse, etc.)
+                // Spawns a sibling session so the voice UI returns to idle immediately
+                // and the user can talk while agents run in parallel.
+                if CodexCLIClient.isAgentTask(transcript) && CodexCLIClient.isAvailable() {
+                    let screenshotsForCodex = screenCaptures.map { (data: $0.imageData, label: $0.label) }
+                    let memoryBlock = memoryCacheSystemPromptBlock
+
+                    // Show the siblings overlay so the user can see the agent running.
+                    agentSiblingsWindowManager.show(sessionManager: agentSessionManager)
+
+                    // Acknowledge the agent task verbally, then go idle so the user
+                    // can keep talking while the agent works in the background.
+                    voiceState = .idle
+                    speakWithMacOSVoice("On it.")
+                    scheduleTransientHideIfNeeded()
+
+                    // Launch the agent — runs entirely in the background.
+                    agentSessionManager.launchAgent(
+                        prompt: transcript,
+                        screenshots: screenshotsForCodex,
+                        memoryContextBlock: memoryBlock,
+                        codexClient: codexCLIClient
+                    ) { [weak self] agentResult in
+                        guard let self else { return }
+                        let trimmedResult = agentResult.trimmingCharacters(in: .whitespacesAndNewlines)
+                        self.conversationHistory.append((userTranscript: transcript, assistantResponse: trimmedResult))
+                        if self.conversationHistory.count > 10 {
+                            self.conversationHistory.removeFirst(self.conversationHistory.count - 10)
+                        }
+                        self.memoryManager.onTurnCompleted(userTranscript: transcript, assistantResponse: trimmedResult)
+                        if !trimmedResult.isEmpty {
+                            self.speakWithMacOSVoice("Done. \(trimmedResult)")
+                        }
+                        // Hide siblings overlay once all agents are finished.
+                        if !self.agentSessionManager.hasAnySessions {
+                            self.agentSiblingsWindowManager.hide()
+                        }
+                    }
+                    return
+                }
+
                 // Build image labels with the actual screenshot pixel dimensions
                 // so Claude's coordinate space matches the image it sees. We
                 // scale from screenshot pixels to display points ourselves.
@@ -637,7 +718,7 @@ final class CompanionManager: ObservableObject {
 
                 let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
                     images: labeledImages,
-                    systemPrompt: Self.companionVoiceResponseSystemPrompt,
+                    systemPrompt: companionVoiceResponseSystemPromptWithMemory,
                     conversationHistory: historyForAPI,
                     userPrompt: userPromptWithAppContext,
                     onTextChunk: { _ in
@@ -717,6 +798,9 @@ final class CompanionManager: ObservableObject {
                 if conversationHistory.count > 10 {
                     conversationHistory.removeFirst(conversationHistory.count - 10)
                 }
+
+                // Persist exchange to disk and extract any memorable facts in the background
+                memoryManager.onTurnCompleted(userTranscript: transcript, assistantResponse: spokenText)
 
                 print("🧠 Conversation history: \(conversationHistory.count) exchanges")
 

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -73,15 +73,30 @@ final class CompanionManager: ObservableObject {
 
     private lazy var claudeAPI: any AnthropicChatClient = {
         // Use the claude CLI subprocess so no separate Anthropic API key is needed.
-        // Falls back to the Cloudflare Worker proxy if the CLI binary is not found.
         if ClaudeCodeCLIClient.isAvailable() {
             print("✅ Using Claude Code CLI subprocess for responses")
             return ClaudeCodeCLIClient(model: selectedModel)
-        } else {
-            print("⚠️ Claude Code CLI not found — falling back to Worker proxy at localhost:8787")
-            return ClaudeAPI(authMode: .proxyURL("http://localhost:8787/chat"), model: selectedModel)
         }
+
+        if let proxyURL = Self.configuredClaudeProxyURL() {
+            print("⚠️ Claude Code CLI not found — using configured Worker proxy")
+            return ClaudeAPI(authMode: .proxyURL(proxyURL), model: selectedModel)
+        }
+
+        print("⚠️ Claude Code CLI not found and no Worker proxy configured — using Claude Code OAuth direct API")
+        return ClaudeAPI(authMode: .claudeCodeOAuth, model: selectedModel)
     }()
+
+    private static func configuredClaudeProxyURL() -> String? {
+        for key in ["ClickyClaudeProxyURL", "ClaudeProxyURL"] {
+            if let urlString = AppBundleConfiguration.stringValue(forKey: key) {
+                return urlString
+            }
+        }
+        let urlString = ProcessInfo.processInfo.environment["CLICKY_CLAUDE_PROXY_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return urlString?.isEmpty == false ? urlString : nil
+    }
 
     /// Codex CLI client for agent tasks ("build me a website", "create a spreadsheet", etc.)
     /// Uses the bundled Codex runtime from /Applications/Clicky.app with the user's Codex subscription.
@@ -92,6 +107,10 @@ final class CompanionManager: ObservableObject {
 
     /// Owns the floating siblings overlay window that shows mini sibling icons.
     private let agentSiblingsWindowManager = AgentSiblingsWindowManager()
+
+    /// Owns the click-to-inspect detail panel that opens when the user taps
+    /// a sibling icon. Renders the session's live Codex output.
+    private let agentSessionDetailWindowManager = AgentSessionDetailWindowManager()
 
     /// Manages persistent memory across sessions: ~/.clicky/memory.md, user.md, history.json.
     private let memoryManager = MemoryManager()
@@ -210,7 +229,22 @@ final class CompanionManager: ObservableObject {
         conversationHistory = sessionContext.seedHistory.suffix(5).map { $0 }
         print("🧠 Codex CLI available: \(CodexCLIClient.isAvailable())")
 
-        // Save memory when the app quits — runs end-of-session summarization
+        // Wire the detail panel's "Send" button to actually send a follow-up
+        // message to the corresponding codex session.
+        agentSessionDetailWindowManager.onSendFollowUp = { [weak self] sessionID, prompt in
+            guard let self else { return }
+            print("🔁 Detail panel follow-up requested for session \(sessionID): \(prompt.prefix(80))")
+            self.agentSessionManager.sendFollowUp(
+                sessionID: sessionID,
+                prompt: prompt,
+                codexClient: self.codexCLIClient
+            )
+        }
+
+        // Save memory when the app quits — runs end-of-session summarization.
+        // ALSO synchronously kill the codex app-server process tree; without
+        // this, every Clicky restart leaks the codex subprocess, which keeps
+        // running indefinitely and consuming the user's quota.
         NotificationCenter.default.addObserver(
             forName: NSApplication.willTerminateNotification,
             object: nil,
@@ -218,6 +252,7 @@ final class CompanionManager: ObservableObject {
         ) { [weak self] _ in
             guard let self else { return }
             self.memoryManager.onSessionEnd(fullSessionHistory: self.conversationHistory)
+            CodexAppServerClient.shared.shutdownSync()
         }
 
         // Eagerly touch the Claude API so its TLS warmup handshake completes
@@ -655,39 +690,83 @@ final class CompanionManager: ObservableObject {
                 // Route to Codex agent for task-oriented requests (build, create, browse, etc.)
                 // Spawns a sibling session so the voice UI returns to idle immediately
                 // and the user can talk while agents run in parallel.
-                if CodexCLIClient.isAgentTask(transcript) && CodexCLIClient.isAvailable() {
-                    let screenshotsForCodex = screenCaptures.map { (data: $0.imageData, label: $0.label) }
+                let isAgent = CodexCLIClient.isAgentTask(transcript)
+                let codexAvailable = CodexCLIClient.isAvailable()
+                print("🎙️ Transcript received: \"\(transcript)\"")
+                print("🤖 isAgentTask: \(isAgent), Codex available: \(codexAvailable)")
+                if isAgent && codexAvailable {
+                    // PRIVACY: do NOT pass screenshots to Codex agents.
+                    // Codex agent tasks (build apps, research, etc.) don't
+                    // need to see the user's screen. Passing the screenshot
+                    // would leak whatever's currently visible — open emails,
+                    // browser tabs, desktop files — to the agent process.
+                    let screenshotsForCodex: [(data: Data, label: String)] = []
                     let memoryBlock = memoryCacheSystemPromptBlock
 
-                    // Show the siblings overlay so the user can see the agent running.
-                    agentSiblingsWindowManager.show(sessionManager: agentSessionManager)
+                    // If the user asked for multiple parallel sessions ("spawn two
+                    // sessions, one for X and one for Y"), decompose into N tasks.
+                    // Tries fast regex first; if that returns 1 task but the user
+                    // clearly asked for multiple, falls back to Haiku for reliable
+                    // splitting across any natural-language phrasing (~2-3s).
+                    let parallelTasks = await CodexCLIClient.decomposeTaskIntoParallelTasksWithLLMFallback(transcript)
+                    print("🤖 Decomposed into \(parallelTasks.count) parallel task(s):")
+                    for (taskIndex, task) in parallelTasks.enumerated() {
+                        print("   #\(taskIndex + 1): \(task)")
+                    }
 
-                    // Acknowledge the agent task verbally, then go idle so the user
-                    // can keep talking while the agent works in the background.
+                    // Show the siblings overlay. The onSelectSession callback
+                    // fires when a sibling icon is tapped — open the detail
+                    // panel anchored to the overlay column at that moment.
+                    agentSiblingsWindowManager.show(
+                        sessionManager: agentSessionManager,
+                        onSelectSession: { [weak self] sessionID, overlayFrame in
+                            guard let self else { return }
+                            self.agentSessionDetailWindowManager.show(
+                                sessionID: sessionID,
+                                sessionManager: self.agentSessionManager,
+                                anchoredTo: overlayFrame
+                            )
+                        }
+                    )
+
+                    // Acknowledge verbally, then go idle so the user can keep talking
+                    // while agents work in the background.
                     voiceState = .idle
-                    speakWithMacOSVoice("On it.")
+                    let acknowledgment = parallelTasks.count > 1
+                        ? "On it. Spawning \(parallelTasks.count) agents."
+                        : "On it."
+                    speakWithMacOSVoice(acknowledgment)
                     scheduleTransientHideIfNeeded()
 
-                    // Launch the agent — runs entirely in the background.
-                    agentSessionManager.launchAgent(
-                        prompt: transcript,
-                        screenshots: screenshotsForCodex,
-                        memoryContextBlock: memoryBlock,
-                        codexClient: codexCLIClient
-                    ) { [weak self] agentResult in
-                        guard let self else { return }
-                        let trimmedResult = agentResult.trimmingCharacters(in: .whitespacesAndNewlines)
-                        self.conversationHistory.append((userTranscript: transcript, assistantResponse: trimmedResult))
-                        if self.conversationHistory.count > 10 {
-                            self.conversationHistory.removeFirst(self.conversationHistory.count - 10)
-                        }
-                        self.memoryManager.onTurnCompleted(userTranscript: transcript, assistantResponse: trimmedResult)
-                        if !trimmedResult.isEmpty {
-                            self.speakWithMacOSVoice("Done. \(trimmedResult)")
-                        }
-                        // Hide siblings overlay once all agents are finished.
-                        if !self.agentSessionManager.hasAnySessions {
-                            self.agentSiblingsWindowManager.hide()
+                    // Launch one sibling per task — they all run in parallel.
+                    for (taskIndex, individualTask) in parallelTasks.enumerated() {
+                        let isMultiTask = parallelTasks.count > 1
+                        agentSessionManager.launchAgent(
+                            prompt: individualTask,
+                            screenshots: screenshotsForCodex,
+                            memoryContextBlock: memoryBlock,
+                            codexClient: codexCLIClient
+                        ) { [weak self] agentResult in
+                            guard let self else { return }
+                            let trimmedResult = agentResult.trimmingCharacters(in: .whitespacesAndNewlines)
+                            self.conversationHistory.append((userTranscript: individualTask, assistantResponse: trimmedResult))
+                            if self.conversationHistory.count > 10 {
+                                self.conversationHistory.removeFirst(self.conversationHistory.count - 10)
+                            }
+                            self.memoryManager.onTurnCompleted(userTranscript: individualTask, assistantResponse: trimmedResult)
+                            // Speak only a short confirmation — NOT the full codex
+                            // output, which can be thousands of characters and
+                            // take minutes to read aloud. The user can click the
+                            // sibling icon to see the full result.
+                            let confirmation = isMultiTask
+                                ? "Task \(taskIndex + 1) ready."
+                                : "Done."
+                            self.speakWithMacOSVoice(confirmation)
+                            // Hide siblings overlay only once ALL agents have finished.
+                            if !self.agentSessionManager.hasAnySessions {
+                                self.agentSiblingsWindowManager.hide()
+                                self.agentSessionDetailWindowManager.hide()
+                            }
                         }
                     }
                     return

--- a/leanring-buddy/MemoryManager.swift
+++ b/leanring-buddy/MemoryManager.swift
@@ -1,0 +1,291 @@
+//
+//  MemoryManager.swift
+//  leanring-buddy
+//
+//  Persistent memory across Clicky sessions, mirroring the BuiltinMemoryProvider
+//  pattern from Hermes Agent (github.com/nousresearch/hermes-agent).
+//
+//  Two tiers — all local, all free:
+//
+//  1. File-based facts: ~/.clicky/memory.md + ~/.clicky/user.md
+//     Claude extracts durable facts from each exchange and appends them here.
+//     Both files are injected into every session's system prompt so Clicky
+//     remembers who you are, what you're working on, and your preferences.
+//
+//  2. Conversation history: ~/.clicky/history.json
+//     The last 20 exchanges are persisted across app restarts. The most recent
+//     5 are seeded into each session's in-memory history so conversations
+//     resume naturally even after quitting and reopening.
+//
+
+import Foundation
+
+final class MemoryManager {
+    // MARK: - Storage paths
+
+    private static let clickyStorageDirectory: URL = {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".clicky")
+    }()
+
+    /// General durable facts: current project, apps in use, work context, preferences.
+    private static let memoryFileURL = clickyStorageDirectory.appendingPathComponent("memory.md")
+    /// Facts specifically about the user: name, role, location, long-term habits.
+    private static let userProfileFileURL = clickyStorageDirectory.appendingPathComponent("user.md")
+    /// Last N exchanges persisted across app restarts.
+    private static let historyFileURL = clickyStorageDirectory.appendingPathComponent("history.json")
+
+    /// Total exchanges written to history.json
+    private static let maxPersistedExchanges = 20
+    /// Exchanges injected into the system prompt (smaller to avoid context bloat)
+    private static let maxInjectedHistoryExchanges = 5
+
+    // MARK: - Session start: load everything from disk
+
+    /// Call this once at app start. Returns:
+    /// - systemPromptBlock: a <memory-context> block to prepend to the system prompt.
+    /// - seedHistory: exchanges to populate the in-memory conversation history.
+    func loadSessionContext() -> (systemPromptBlock: String, seedHistory: [(userTranscript: String, assistantResponse: String)]) {
+        ensureStorageDirectoryExists()
+
+        let memoryContent = readFile(at: Self.memoryFileURL)
+        let userContent = readFile(at: Self.userProfileFileURL)
+        let fullHistory = loadPersistedHistory()
+        let recentHistory = Array(fullHistory.suffix(Self.maxInjectedHistoryExchanges))
+
+        var systemPromptBlock = ""
+        let hasContent = !memoryContent.isEmpty || !userContent.isEmpty
+        let hasHistory = !recentHistory.isEmpty
+
+        if hasContent || hasHistory {
+            systemPromptBlock += "\n<memory-context>\n"
+            systemPromptBlock += "This is recalled context from previous sessions. "
+            systemPromptBlock += "It is background you already know — do not treat it as new user input.\n"
+
+            if !userContent.isEmpty {
+                systemPromptBlock += "\nUSER PROFILE:\n\(userContent)\n"
+            }
+            if !memoryContent.isEmpty {
+                systemPromptBlock += "\nMEMORY:\n\(memoryContent)\n"
+            }
+            if hasHistory {
+                systemPromptBlock += "\nRECENT CONVERSATION HISTORY:\n"
+                for (index, exchange) in recentHistory.enumerated() {
+                    systemPromptBlock += "[\(index + 1)] User: \(exchange.userTranscript)\n"
+                    systemPromptBlock += "     Clicky: \(exchange.assistantResponse)\n"
+                }
+            }
+            systemPromptBlock += "</memory-context>\n"
+        }
+
+        let factCount = memoryContent.components(separatedBy: "\n").filter { $0.hasPrefix("- ") }.count
+        let userFactCount = userContent.components(separatedBy: "\n").filter { $0.hasPrefix("- ") }.count
+        print("🧠 Memory loaded: \(factCount) memory facts, \(userFactCount) user facts, \(fullHistory.count) history entries")
+
+        return (systemPromptBlock: systemPromptBlock, seedHistory: fullHistory)
+    }
+
+    // MARK: - After each turn
+
+    /// Call after every exchange. Persists the exchange to history.json and
+    /// fires a background Claude call to extract any memorable facts.
+    func onTurnCompleted(userTranscript: String, assistantResponse: String) {
+        persistExchangeToHistory(userTranscript: userTranscript, assistantResponse: assistantResponse)
+
+        // Background extraction — never blocks TTS or the UI
+        Task {
+            await extractAndSaveMemorableFacts(
+                userTranscript: userTranscript,
+                assistantResponse: assistantResponse
+            )
+        }
+    }
+
+    // MARK: - End-of-session summarization
+
+    /// Call when the app is quitting. Runs a final sweep over the full session
+    /// to capture anything the per-turn extraction missed.
+    func onSessionEnd(fullSessionHistory: [(userTranscript: String, assistantResponse: String)]) {
+        guard !fullSessionHistory.isEmpty else { return }
+        Task {
+            await runEndOfSessionSummarization(history: fullSessionHistory)
+        }
+    }
+
+    // MARK: - File I/O
+
+    private func ensureStorageDirectoryExists() {
+        let dir = Self.clickyStorageDirectory
+        guard !FileManager.default.fileExists(atPath: dir.path) else { return }
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    private func readFile(at url: URL) -> String {
+        (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    }
+
+    private func writeFile(content: String, to url: URL) {
+        try? content.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - History persistence
+
+    private func loadPersistedHistory() -> [(userTranscript: String, assistantResponse: String)] {
+        guard let data = try? Data(contentsOf: Self.historyFileURL),
+              let rawArray = try? JSONSerialization.jsonObject(with: data) as? [[String: String]]
+        else { return [] }
+        return rawArray.compactMap { dict in
+            guard let user = dict["user"], let assistant = dict["assistant"] else { return nil }
+            return (userTranscript: user, assistantResponse: assistant)
+        }
+    }
+
+    private func persistExchangeToHistory(userTranscript: String, assistantResponse: String) {
+        var history = loadPersistedHistory()
+        history.append((userTranscript: userTranscript, assistantResponse: assistantResponse))
+        if history.count > Self.maxPersistedExchanges {
+            history = Array(history.suffix(Self.maxPersistedExchanges))
+        }
+        let serializable: [[String: String]] = history.map {
+            ["user": $0.userTranscript, "assistant": $0.assistantResponse]
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: serializable, options: .prettyPrinted) {
+            try? data.write(to: Self.historyFileURL)
+        }
+    }
+
+    // MARK: - Memory extraction via Claude
+
+    /// Background call to Claude (via Claude Code CLI subprocess) after each turn.
+    /// Extracts any NEW facts worth remembering and appends them to memory.md / user.md.
+    /// Uses the CLI subprocess so the Claude Code subscription handles auth — no direct API key needed.
+    private func extractAndSaveMemorableFacts(userTranscript: String, assistantResponse: String) async {
+        guard let extractionClient = makeExtractionClient() else { return }
+
+        let existingMemory = readFile(at: Self.memoryFileURL)
+        let existingUserProfile = readFile(at: Self.userProfileFileURL)
+
+        let systemPrompt = "You extract durable facts from conversations for persistent memory. Reply only with valid JSON — no markdown fences, no prose, no explanation."
+
+        let prompt = """
+        Extract any NEW durable facts from this conversation exchange worth remembering in future sessions.
+
+        Exchange:
+        User: \(userTranscript)
+        Clicky: \(assistantResponse)
+
+        Current memory.md (do NOT repeat these):
+        \(existingMemory.isEmpty ? "(empty)" : existingMemory)
+
+        Current user.md (do NOT repeat these):
+        \(existingUserProfile.isEmpty ? "(empty)" : existingUserProfile)
+
+        Rules:
+        - Only extract facts that are durable across sessions (projects, preferences, identity)
+        - Never extract one-off questions, small talk, or session-specific details
+        - Never repeat anything already in the current files above
+        - memory.md: current projects, apps, tools, work context, stated preferences
+        - user.md: user's name, role, location, personality, long-term habits
+        - If nothing new: return {}
+
+        Return ONLY valid JSON, no markdown fences, no prose:
+        {"memory": ["fact1"], "user": ["fact1"]}
+        """
+
+        do {
+            let (json, _) = try await extractionClient.analyzeImageStreaming(
+                images: [],
+                systemPrompt: systemPrompt,
+                conversationHistory: [],
+                userPrompt: prompt,
+                onTextChunk: { _ in }
+            )
+            applyExtractedFacts(from: json)
+        } catch {
+            print("🧠 Memory extraction failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Called at session end — does a final pass over the full session history.
+    private func runEndOfSessionSummarization(history: [(userTranscript: String, assistantResponse: String)]) async {
+        guard let extractionClient = makeExtractionClient() else { return }
+
+        let existingMemory = readFile(at: Self.memoryFileURL)
+        let existingUserProfile = readFile(at: Self.userProfileFileURL)
+
+        let historyText = history.enumerated().map { index, exchange in
+            "Turn \(index + 1)\nUser: \(exchange.userTranscript)\nClicky: \(exchange.assistantResponse)"
+        }.joined(separator: "\n\n")
+
+        let prompt = """
+        Review this full conversation session and extract any NEW durable facts not already captured.
+
+        Full session:
+        \(historyText)
+
+        Current memory.md:
+        \(existingMemory.isEmpty ? "(empty)" : existingMemory)
+
+        Current user.md:
+        \(existingUserProfile.isEmpty ? "(empty)" : existingUserProfile)
+
+        Return ONLY valid JSON — no prose, no markdown:
+        {"memory": ["fact1"], "user": ["fact1"]}
+        If nothing new: {}
+        """
+
+        do {
+            let (json, _) = try await extractionClient.analyzeImageStreaming(
+                images: [],
+                systemPrompt: "You extract durable facts from conversations for persistent memory. Reply only with valid JSON.",
+                conversationHistory: [],
+                userPrompt: prompt,
+                onTextChunk: { _ in }
+            )
+            applyExtractedFacts(from: json)
+            print("🧠 End-of-session memory sweep complete")
+        } catch {
+            print("🧠 End-of-session sweep failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func applyExtractedFacts(from jsonString: String) {
+        // Strip markdown code fences if the model adds them despite instructions
+        var cleaned = jsonString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.hasPrefix("```") {
+            cleaned = cleaned.components(separatedBy: "\n").dropFirst().dropLast().joined(separator: "\n")
+        }
+
+        guard let data = cleaned.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: [String]]
+        else { return }
+
+        if let memoryFacts = parsed["memory"], !memoryFacts.isEmpty {
+            appendNewFacts(memoryFacts, to: Self.memoryFileURL)
+            print("🧠 memory.md +\(memoryFacts.count): \(memoryFacts.joined(separator: " | "))")
+        }
+        if let userFacts = parsed["user"], !userFacts.isEmpty {
+            appendNewFacts(userFacts, to: Self.userProfileFileURL)
+            print("🧠 user.md +\(userFacts.count): \(userFacts.joined(separator: " | "))")
+        }
+    }
+
+    private func appendNewFacts(_ facts: [String], to fileURL: URL) {
+        let existing = readFile(at: fileURL)
+        let newLines = facts.map { "- \($0)" }.joined(separator: "\n")
+        let updated = existing.isEmpty ? newLines : existing + "\n" + newLines
+        writeFile(content: updated, to: fileURL)
+    }
+
+    // MARK: - Extraction client
+
+    /// Creates a ClaudeCodeCLIClient for background extractions.
+    /// Routes through the Claude Code CLI subprocess so the subscription handles auth — no direct API key needed.
+    /// Returns nil if Claude Code CLI is not installed.
+    private func makeExtractionClient() -> (any AnthropicChatClient)? {
+        guard ClaudeCodeCLIClient.isAvailable() else {
+            print("🧠 Skipping memory extraction — Claude Code CLI not found")
+            return nil
+        }
+        return ClaudeCodeCLIClient(model: "claude-haiku-4-5-20251001")
+    }
+}

--- a/leanring-buddy/MemoryManager.swift
+++ b/leanring-buddy/MemoryManager.swift
@@ -164,30 +164,51 @@ final class MemoryManager {
         let existingMemory = readFile(at: Self.memoryFileURL)
         let existingUserProfile = readFile(at: Self.userProfileFileURL)
 
-        let systemPrompt = "You extract durable facts from conversations for persistent memory. Reply only with valid JSON — no markdown fences, no prose, no explanation."
+        let systemPrompt = "You extract durable facts from conversations for persistent memory. Write facts the way a friend would jot a quick note about someone — short, plain, specific. Reply only with valid JSON, no markdown, no prose."
 
         let prompt = """
-        Extract any NEW durable facts from this conversation exchange worth remembering in future sessions.
+        Look at this exchange and pull out any NEW durable facts worth remembering next session.
 
         Exchange:
         User: \(userTranscript)
         Clicky: \(assistantResponse)
 
-        Current memory.md (do NOT repeat these):
+        Already in memory.md (skip these):
         \(existingMemory.isEmpty ? "(empty)" : existingMemory)
 
-        Current user.md (do NOT repeat these):
+        Already in user.md (skip these):
         \(existingUserProfile.isEmpty ? "(empty)" : existingUserProfile)
 
-        Rules:
-        - Only extract facts that are durable across sessions (projects, preferences, identity)
-        - Never extract one-off questions, small talk, or session-specific details
-        - Never repeat anything already in the current files above
-        - memory.md: current projects, apps, tools, work context, stated preferences
-        - user.md: user's name, role, location, personality, long-term habits
-        - If nothing new: return {}
+        Voice & style — facts must read like a friend's quick note:
+        - Short sentences, plain words. No corporate language. No "the user".
+        - Be specific. "Loves espresso" beats "consumes coffee beverages".
+        - One idea per fact. Don't pile clauses.
+        - Skip obvious or generic stuff ("uses a computer").
+        - NEVER paste raw file paths, screenshot/PNG names, JSON, tool names,
+          terminal output, log fragments, UUIDs, or session-specific details.
+          If something only makes sense in this exact session, skip it.
+        - Translate tech artifacts into a human observation. Example:
+          screenshot "/var/.../IMG_4422.png" → "Was looking at his photo library."
+          NOT "User opened IMG_4422.png".
+        - If nothing new is worth remembering: return {}
 
-        Return ONLY valid JSON, no markdown fences, no prose:
+        Examples of GOOD facts:
+        - "Building Clicky — a Mac menu-bar AI app."
+        - "Prefers Sonnet 4.6 over Opus."
+        - "Hates being asked clarifying questions before work starts."
+        - "Lives in NYC, lifts at Equinox before work."
+
+        Examples of BAD facts (too literal / robotic / session-specific):
+        - "User builds web applications using HTML/JavaScript and strongly prefers standalone solutions that open directly in browser without server requirements"
+        - "User has expressed interest in productivity tooling"
+        - "User opened /Users/gagan/Desktop/screenshot.png to discuss UI"
+        - "User invoked agent task with prompt 'build me a snake game'"
+
+        What goes where:
+        - memory.md: current projects, tools they use, stated preferences, work context
+        - user.md: name, role, location, personality, long-term habits
+
+        Return ONLY valid JSON:
         {"memory": ["fact1"], "user": ["fact1"]}
         """
 
@@ -217,26 +238,38 @@ final class MemoryManager {
         }.joined(separator: "\n\n")
 
         let prompt = """
-        Review this full conversation session and extract any NEW durable facts not already captured.
+        Skim this full session and pull out any NEW durable facts not already captured.
 
         Full session:
         \(historyText)
 
-        Current memory.md:
+        Already in memory.md (skip these):
         \(existingMemory.isEmpty ? "(empty)" : existingMemory)
 
-        Current user.md:
+        Already in user.md (skip these):
         \(existingUserProfile.isEmpty ? "(empty)" : existingUserProfile)
 
-        Return ONLY valid JSON — no prose, no markdown:
+        Voice & style — write like a friend's quick note:
+        - Short sentences. Plain words. No "the user".
+        - Be specific. "Loves espresso" beats "consumes coffee beverages".
+        - One idea per fact.
+        - Skip obvious / generic stuff.
+        - NEVER paste file paths, PNG names, JSON, tool names, terminal output,
+          UUIDs, or session-specific details. Translate tech artifacts into
+          a plain human observation, or skip them.
+        - If nothing new: return {}
+
+        memory.md: projects, tools, preferences, work context
+        user.md: name, role, location, personality, long-term habits
+
+        Return ONLY valid JSON:
         {"memory": ["fact1"], "user": ["fact1"]}
-        If nothing new: {}
         """
 
         do {
             let (json, _) = try await extractionClient.analyzeImageStreaming(
                 images: [],
-                systemPrompt: "You extract durable facts from conversations for persistent memory. Reply only with valid JSON.",
+                systemPrompt: "You extract durable facts from conversations for persistent memory. Write like a friend's quick note — short, plain, specific. Reply only with valid JSON.",
                 conversationHistory: [],
                 userPrompt: prompt,
                 onTextChunk: { _ in }

--- a/scripts/install-to-applications.sh
+++ b/scripts/install-to-applications.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Post-build script: copies the freshly-built Clicky.app to /Applications/Clicky.app.
+# Add this as a "Run Script" Build Phase in Xcode (after the Compile Sources phase).
+#
+# In Xcode: Target → Build Phases → + → New Run Script Phase
+# Paste the body of this file (the lines after this comment block) into the script field.
+# Set "Based on dependency analysis" to OFF so it always runs.
+
+set -e
+
+BUILT_APP="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app"
+INSTALL_PATH="/Applications/Clicky.app"
+
+if [ ! -d "$BUILT_APP" ]; then
+  echo "warning: Built app not found at $BUILT_APP — skipping install"
+  exit 0
+fi
+
+echo "Installing $BUILT_APP → $INSTALL_PATH"
+
+# Kill the running Clicky (if any) before replacing the binary
+pkill -x Clicky 2>/dev/null || true
+sleep 0.5
+
+# Copy the built app over, replacing the existing one
+cp -Rf "$BUILT_APP" "$INSTALL_PATH"
+
+echo "✅ Installed to $INSTALL_PATH"


### PR DESCRIPTION
## Summary
- Integrates the approved sibling-agent base on top of the current green `origin/main`.
- Adds the Codex app-server client path, session detail panel/follow-ups, and lifecycle teardown for agent sessions.
- Fixes session close behavior by sending `turn/interrupt` with the required `turnId`, then `thread/archive` plus `thread/unsubscribe`.
- Adds app termination cleanup for the Codex process tree and a parent-PID watchdog for Xcode Stop.
- Removes localhost-only transcription proxy defaults from the integrated path.

## Verification
- `git diff --check`
- `plutil -lint leanring-buddy.xcodeproj/project.pbxproj`
- `rg -n "localhost:8787|127\\.0\\.0\\.1:8787" leanring-buddy worker || true`
- `xcrun swiftc -parse` on the changed Swift files
- `xcrun swiftc -typecheck` on the focused agent/Codex dependency set; typecheck passed with existing Swift 6 concurrency warnings in legacy CLI streaming clients
- Generated local Codex app-server JSON schemas and verified the lifecycle method shapes
- Runtime smoke-tested app-server `initialize`, `thread/start`, and `thread/unsubscribe` over stdio without running an agent turn

## Notes
- I did not run local `xcodebuild`; this repo warns that terminal `xcodebuild` can invalidate macOS TCC permissions. GitHub CI should be the source of truth for the full Xcode build.
- I intentionally did not wholesale merge the experimental `computer-use-agent`, `madison-v1`, or `managua` dirty worktrees because they overlap heavily in `CompanionManager` and should be integrated separately after this lifecycle PR is green.