### PR TITLE
[codex] Fix parallel Codex session routing

### DIFF
--- a/leanring-buddy/CodexCLIClient.swift
+++ b/leanring-buddy/CodexCLIClient.swift
@@ -86,6 +86,11 @@ final class CodexCLIClient {
             "codex session", "codex agent", "codex sessions", "codex agents",
             "another codex", "another agent", "another session",
             "new codex", "new agent",
+            "parallel codex", "parallel agent", "parallel session",
+            "run 2 sessions", "run two sessions",
+            "start 2 sessions", "start two sessions",
+            "session 1", "session one", "mission 1", "mission one",
+            "task 1", "task one",
             "spawn an agent", "spawn agent",
             "fire up an agent", "fire up a codex",
             "launch an agent", "launch a codex",
@@ -126,6 +131,7 @@ final class CodexCLIClient {
     ///   "agent, build me a snake game"  → unchanged (single task)
     static func decomposeTaskIntoParallelTasks(_ transcript: String) -> [String] {
         let lower = transcript.lowercased()
+        let requestedCount = requestedParallelSessionCount(in: lower)
 
         // Only consider splitting if the user explicitly mentioned multiple sessions / agents.
         // This avoids splitting "build me a calculator and a button" into two unrelated tasks.
@@ -133,14 +139,21 @@ final class CodexCLIClient {
             "spawn ",
             "parallel",
             "in parallel",
+            "2 sessions", "3 sessions", "4 sessions", "5 sessions",
+            "2 agents", "3 agents", "4 agents", "5 agents",
+            "2 codex", "3 codex", "4 codex", "5 codex",
+            "codex sessions", "codex agents",
             "two sessions", "three sessions", "four sessions", "five sessions",
             "two agents", "three agents", "four agents", "five agents",
             "multiple agents", "multiple sessions",
             "siblings",
             "one for",
             "one to",
+            "session 1", "session one", "session 2", "session two",
+            "mission 1", "mission one", "mission 2", "mission two",
+            "task 1", "task one", "task 2", "task two",
         ]
-        let isMultiSession = multiSessionMarkers.contains { lower.contains($0) }
+        let isMultiSession = requestedCount != nil || multiSessionMarkers.contains { lower.contains($0) }
         guard isMultiSession else { return [transcript] }
 
         // Split on enumeration markers people say in natural English when
@@ -154,6 +167,7 @@ final class CodexCLIClient {
         // and digits are allowed bare; "agent"/"session"/"task" alone are
         // NOT, to avoid matching "the agent" etc.):
         //   • one
+        //   • (mission|session|task|agent) (1|2|3|...|one|two|three|...)
         //   • the other (one|agent|session|task)
         //   • another (one|agent|session|task)
         //   • (first|second|third|fourth|fifth) [(one|agent|session|task)]
@@ -164,7 +178,7 @@ final class CodexCLIClient {
         //   "the other one IS to make X"
         //   "another one WILL TO do X"
         //   "second one NEEDS to find X"
-        let collapsedSplitPattern = #"\b(?:(?:(?:the\s+)?other\s+|another\s+)(?:one|agent|session|task)|one|(?:first|second|third|fourth|fifth)(?:\s+(?:one|agent|session|task))?|[1-9])\b(?:[,.):]\s*(?:(?:to|for)\b\s*)?|\s+(?:(?:is|was|are|were|will|would|should|shall|needs?|has|have|had|can|could|may|might|must|just)\s+)?(?:to|for)\b\s*)"#
+        let collapsedSplitPattern = #"\b(?:(?:(?:mission|session|task|agent)\s+)(?:[1-9]|one|two|three|four|five|six|seven|eight|nine)|(?:(?:the\s+)?other\s+|another\s+)(?:one|agent|session|task)|one|(?:first|second|third|fourth|fifth)(?:\s+(?:one|agent|session|task))?|[1-9])\b(?:[,.):]\s*(?:(?:to|for)\b\s*)?|\s+(?:(?:is|was|are|were|will|would|should|shall|needs?|has|have|had|can|could|may|might|must|just)\s+)?(?:to|for)\b\s*)"#
         // Use a sentinel that won't appear in spoken transcripts.
         let splitSentinel = "\u{FFFC}"
         let normalized = transcript.replacingOccurrences(
@@ -174,11 +188,12 @@ final class CodexCLIClient {
         )
 
         if normalized.contains(splitSentinel) {
+            let taskBoundaryTrimmingCharacters = CharacterSet(charactersIn: " ,.?;:!\n\t")
             let parts = normalized
                 .components(separatedBy: splitSentinel)
                 .dropFirst() // discard preamble before the first "one for"
                 .map { rawTask -> String in
-                    var cleaned = rawTask.trimmingCharacters(in: CharacterSet(charactersIn: " ,.?;:!"))
+                    var cleaned = rawTask.trimmingCharacters(in: taskBoundaryTrimmingCharacters)
                     // Strip trailing connectors like "and" or "and then"
                     let trailingConnectors = [" and then", " and"]
                     for connector in trailingConnectors {
@@ -193,7 +208,7 @@ final class CodexCLIClient {
                             cleaned = String(cleaned.dropFirst(filler.count))
                         }
                     }
-                    return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return cleaned.trimmingCharacters(in: taskBoundaryTrimmingCharacters)
                 }
                 .filter { !$0.isEmpty }
             if parts.count >= 2 {
@@ -201,7 +216,43 @@ final class CodexCLIClient {
             }
         }
 
+        if let requestedCount, requestedCount >= 2 {
+            return (1...requestedCount).map { index in
+                "Parallel Codex session \(index): confirm this independent Codex session is running and briefly state that it is ready for a follow-up task."
+            }
+        }
+
         return [transcript]
+    }
+
+    private static func requestedParallelSessionCount(in lower: String) -> Int? {
+        let numberWords = [
+            "two": 2, "three": 3, "four": 4, "five": 5,
+            "six": 6, "seven": 7, "eight": 8, "nine": 9,
+        ]
+        let numberPattern = #"([2-9]|two|three|four|five|six|seven|eight|nine)"#
+        let nounPattern = #"(?:parallel\s+)?(?:codex\s+)?(?:sessions?|agents?|siblings)"#
+        let patterns = [
+            #"\#(numberPattern)\s+\#(nounPattern)"#,
+            #"\#(nounPattern)\s+\#(numberPattern)"#,
+        ]
+
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { continue }
+            let range = NSRange(lower.startIndex..<lower.endIndex, in: lower)
+            guard let match = regex.firstMatch(in: lower, range: range), match.numberOfRanges >= 2 else { continue }
+            for groupIndex in 1..<match.numberOfRanges {
+                guard let groupRange = Range(match.range(at: groupIndex), in: lower) else { continue }
+                let token = String(lower[groupRange])
+                if let digit = Int(token) {
+                    return min(max(digit, 2), 9)
+                }
+                if let wordValue = numberWords[token] {
+                    return wordValue
+                }
+            }
+        }
+        return nil
     }
 
     /// Returns the parallel task list for a transcript. First tries the fast
@@ -218,6 +269,7 @@ final class CodexCLIClient {
         let lower = transcript.lowercased()
         let multiSessionMarkers = [
             "spawn ", "parallel", "in parallel",
+            "2 sessions", "3 sessions", "2 agents", "3 agents",
             "two sessions", "three sessions", "two agents", "three agents",
             "multiple agents", "multiple sessions", "siblings",
             "second agent", "second session",

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -664,6 +664,83 @@ final class CompanionManager: ObservableObject {
     - element is on screen 2 (not where cursor is): "that's over on your other monitor — see the terminal window? [POINT:400,300:terminal:screen2]"
     """
 
+    private func routeTranscriptToCodexIfNeeded(_ transcript: String) async -> Bool {
+        // Route to Codex before screenshot capture. Agent tasks do not need
+        // screen pixels, and avoiding capture keeps multi-agent requests snappy.
+        let isAgent = CodexCLIClient.isAgentTask(transcript)
+        let codexAvailable = CodexCLIClient.isAvailable()
+        print("🎙️ Transcript received: \"\(transcript)\"")
+        print("🤖 isAgentTask: \(isAgent), Codex available: \(codexAvailable)")
+        guard isAgent && codexAvailable else { return false }
+
+        // PRIVACY: do NOT pass screenshots to Codex agents. Codex tasks
+        // should not receive visible emails, browser tabs, files, or other
+        // sensitive desktop state unless the user explicitly provides it.
+        let screenshotsForCodex: [(data: Data, label: String)] = []
+        let memoryBlock = memoryCacheSystemPromptBlock
+
+        // If the user asked for multiple parallel sessions ("spawn two
+        // sessions, one for X and one for Y"), decompose into N tasks.
+        let parallelTasks = await CodexCLIClient.decomposeTaskIntoParallelTasksWithLLMFallback(transcript)
+        print("🤖 Decomposed into \(parallelTasks.count) parallel task(s):")
+        for (taskIndex, task) in parallelTasks.enumerated() {
+            print("   #\(taskIndex + 1): \(task)")
+        }
+
+        // Show the siblings overlay. The onSelectSession callback fires when
+        // a sibling icon is tapped, opening the detail panel anchored there.
+        agentSiblingsWindowManager.show(
+            sessionManager: agentSessionManager,
+            onSelectSession: { [weak self] sessionID, overlayFrame in
+                guard let self else { return }
+                self.agentSessionDetailWindowManager.show(
+                    sessionID: sessionID,
+                    sessionManager: self.agentSessionManager,
+                    anchoredTo: overlayFrame
+                )
+            }
+        )
+
+        // Acknowledge verbally, then go idle so the user can keep talking
+        // while agents work in the background.
+        voiceState = .idle
+        let acknowledgment = parallelTasks.count > 1
+            ? "On it. Spawning \(parallelTasks.count) agents."
+            : "On it."
+        speakWithMacOSVoice(acknowledgment)
+        scheduleTransientHideIfNeeded()
+
+        // Launch one sibling per task — they all run in parallel.
+        for (taskIndex, individualTask) in parallelTasks.enumerated() {
+            let isMultiTask = parallelTasks.count > 1
+            agentSessionManager.launchAgent(
+                prompt: individualTask,
+                screenshots: screenshotsForCodex,
+                memoryContextBlock: memoryBlock,
+                codexClient: codexCLIClient
+            ) { [weak self] agentResult in
+                guard let self else { return }
+                let trimmedResult = agentResult.trimmingCharacters(in: .whitespacesAndNewlines)
+                self.conversationHistory.append((userTranscript: individualTask, assistantResponse: trimmedResult))
+                if self.conversationHistory.count > 10 {
+                    self.conversationHistory.removeFirst(self.conversationHistory.count - 10)
+                }
+                self.memoryManager.onTurnCompleted(userTranscript: individualTask, assistantResponse: trimmedResult)
+                // Speak only a short confirmation. The user can click the
+                // sibling icon to see the full result.
+                let confirmation = isMultiTask
+                    ? "Task \(taskIndex + 1) ready."
+                    : "Done."
+                self.speakWithMacOSVoice(confirmation)
+                if !self.agentSessionManager.hasAnySessions {
+                    self.agentSiblingsWindowManager.hide()
+                    self.agentSessionDetailWindowManager.hide()
+                }
+            }
+        }
+        return true
+    }
+
     // MARK: - AI Response Pipeline
 
     /// Captures a screenshot, sends it along with the transcript to Claude,
@@ -682,95 +759,14 @@ final class CompanionManager: ObservableObject {
             voiceState = .processing
 
             do {
+                if await routeTranscriptToCodexIfNeeded(transcript) {
+                    return
+                }
+
                 // Capture all connected screens so the AI has full context
                 let screenCaptures = try await CompanionScreenCaptureUtility.captureAllScreensAsJPEG()
 
                 guard !Task.isCancelled else { return }
-
-                // Route to Codex agent for task-oriented requests (build, create, browse, etc.)
-                // Spawns a sibling session so the voice UI returns to idle immediately
-                // and the user can talk while agents run in parallel.
-                let isAgent = CodexCLIClient.isAgentTask(transcript)
-                let codexAvailable = CodexCLIClient.isAvailable()
-                print("🎙️ Transcript received: \"\(transcript)\"")
-                print("🤖 isAgentTask: \(isAgent), Codex available: \(codexAvailable)")
-                if isAgent && codexAvailable {
-                    // PRIVACY: do NOT pass screenshots to Codex agents.
-                    // Codex agent tasks (build apps, research, etc.) don't
-                    // need to see the user's screen. Passing the screenshot
-                    // would leak whatever's currently visible — open emails,
-                    // browser tabs, desktop files — to the agent process.
-                    let screenshotsForCodex: [(data: Data, label: String)] = []
-                    let memoryBlock = memoryCacheSystemPromptBlock
-
-                    // If the user asked for multiple parallel sessions ("spawn two
-                    // sessions, one for X and one for Y"), decompose into N tasks.
-                    // Tries fast regex first; if that returns 1 task but the user
-                    // clearly asked for multiple, falls back to Haiku for reliable
-                    // splitting across any natural-language phrasing (~2-3s).
-                    let parallelTasks = await CodexCLIClient.decomposeTaskIntoParallelTasksWithLLMFallback(transcript)
-                    print("🤖 Decomposed into \(parallelTasks.count) parallel task(s):")
-                    for (taskIndex, task) in parallelTasks.enumerated() {
-                        print("   #\(taskIndex + 1): \(task)")
-                    }
-
-                    // Show the siblings overlay. The onSelectSession callback
-                    // fires when a sibling icon is tapped — open the detail
-                    // panel anchored to the overlay column at that moment.
-                    agentSiblingsWindowManager.show(
-                        sessionManager: agentSessionManager,
-                        onSelectSession: { [weak self] sessionID, overlayFrame in
-                            guard let self else { return }
-                            self.agentSessionDetailWindowManager.show(
-                                sessionID: sessionID,
-                                sessionManager: self.agentSessionManager,
-                                anchoredTo: overlayFrame
-                            )
-                        }
-                    )
-
-                    // Acknowledge verbally, then go idle so the user can keep talking
-                    // while agents work in the background.
-                    voiceState = .idle
-                    let acknowledgment = parallelTasks.count > 1
-                        ? "On it. Spawning \(parallelTasks.count) agents."
-                        : "On it."
-                    speakWithMacOSVoice(acknowledgment)
-                    scheduleTransientHideIfNeeded()
-
-                    // Launch one sibling per task — they all run in parallel.
-                    for (taskIndex, individualTask) in parallelTasks.enumerated() {
-                        let isMultiTask = parallelTasks.count > 1
-                        agentSessionManager.launchAgent(
-                            prompt: individualTask,
-                            screenshots: screenshotsForCodex,
-                            memoryContextBlock: memoryBlock,
-                            codexClient: codexCLIClient
-                        ) { [weak self] agentResult in
-                            guard let self else { return }
-                            let trimmedResult = agentResult.trimmingCharacters(in: .whitespacesAndNewlines)
-                            self.conversationHistory.append((userTranscript: individualTask, assistantResponse: trimmedResult))
-                            if self.conversationHistory.count > 10 {
-                                self.conversationHistory.removeFirst(self.conversationHistory.count - 10)
-                            }
-                            self.memoryManager.onTurnCompleted(userTranscript: individualTask, assistantResponse: trimmedResult)
-                            // Speak only a short confirmation — NOT the full codex
-                            // output, which can be thousands of characters and
-                            // take minutes to read aloud. The user can click the
-                            // sibling icon to see the full result.
-                            let confirmation = isMultiTask
-                                ? "Task \(taskIndex + 1) ready."
-                                : "Done."
-                            self.speakWithMacOSVoice(confirmation)
-                            // Hide siblings overlay only once ALL agents have finished.
-                            if !self.agentSessionManager.hasAnySessions {
-                                self.agentSiblingsWindowManager.hide()
-                                self.agentSessionDetailWindowManager.hide()
-                            }
-                        }
-                    }
-                    return
-                }
 
                 // Build image labels with the actual screenshot pixel dimensions
                 // so Claude's coordinate space matches the image it sees. We

--- a/leanring-buddyTests/leanring_buddyTests.swift
+++ b/leanring-buddyTests/leanring_buddyTests.swift
@@ -37,4 +37,26 @@ struct leanring_buddyTests {
         #expect(shouldTreatPermissionAsGranted)
     }
 
+    @Test func enumeratedSessionFollowUpRoutesToCodexAgents() async throws {
+        let transcript = "Mission 1: Find people who might be interested in Clikki. And session 2, um, find me a list of YC startups doing something similar to Clicky."
+
+        #expect(CodexCLIClient.isAgentTask(transcript))
+
+        let tasks = CodexCLIClient.decomposeTaskIntoParallelTasks(transcript)
+        #expect(tasks.count == 2)
+        #expect(tasks[0] == "Find people who might be interested in Clikki")
+        #expect(tasks[1] == "find me a list of YC startups doing something similar to Clicky")
+    }
+
+    @Test func explicitTwoCodexSessionsCreatesTwoDemoTasks() async throws {
+        let transcript = "Can you run 2 sessions for me? 2 parallel Codex sessions"
+
+        #expect(CodexCLIClient.isAgentTask(transcript))
+
+        let tasks = CodexCLIClient.decomposeTaskIntoParallelTasks(transcript)
+        #expect(tasks.count == 2)
+        #expect(tasks[0].contains("Parallel Codex session 1"))
+        #expect(tasks[1].contains("Parallel Codex session 2"))
+    }
+
 }


### PR DESCRIPTION
## Summary
- Route Codex agent requests before screenshot capture so multi-session prompts respond faster and avoid unnecessary screen context work.
- Detect spoken forms like `run 2 sessions`, `2 parallel Codex sessions`, and `Mission 1 ... session 2 ...` as Codex agent work.
- Split enumerated mission/session/task prompts into clean independent prompts and add regression coverage for the two-session launch path.

## Root Cause
The previous parser missed some common spoken multi-session phrases and split `Mission 1 ... session 2 ...` at the number only, leaving connector text attached to the first task. Agent routing also happened after screenshot capture, making Codex requests feel slower than needed.

## Validation
- `git diff --check`
- `xcrun swiftc -parse leanring-buddy/CodexCLIClient.swift leanring-buddy/CompanionManager.swift leanring-buddyTests/leanring_buddyTests.swift`
- Targeted Swift decomposition harness covering `run 2 sessions`, `Mission 1 ... session 2 ...`, and `one to ... one to ...` prompts

Note: local Xcode build was not run from terminal to avoid the repo local TCC guidance.