### PR TITLE
[codex] Speed up Clicky voice actions

### DIFF
--- a/leanring-buddy/ActionTagParser.swift
+++ b/leanring-buddy/ActionTagParser.swift
@@ -1,0 +1,195 @@
+//
+//  ActionTagParser.swift
+//  leanring-buddy
+//
+//  Parses structured tags Claude embeds in its response text — currently
+//  the [POINT:x,y:label:screenN] coordinate tag, with future native action
+//  tags ([CLICK], [TYPE], [KEY], etc.) to be added in subsequent phases.
+//
+//  This file is the single source of truth for tag syntax so CompanionManager
+//  doesn't need to know how the tag grammar works.
+//
+
+import CoreGraphics
+import Foundation
+
+/// Result of parsing a [POINT:...] tag from Claude's response.
+struct PointingParseResult {
+    /// The response text with the [POINT:...] tag removed — this is what gets spoken.
+    let spokenText: String
+    /// The parsed pixel coordinate, or nil if Claude said "none" or no tag was found.
+    let coordinate: CGPoint?
+    /// Short label describing the element (e.g. "run button"), or "none".
+    let elementLabel: String?
+    /// Which screen the coordinate refers to (1-based), or nil to default to cursor screen.
+    let screenNumber: Int?
+}
+
+/// Result of parsing the full set of structured tags Claude can emit:
+/// `[POINT:...]`, `[OPEN_APP:...]`, `[QUIT_APP:...]`, `[CLICK:...]`,
+/// `[TYPE:...]`, `[KEY:...]`, `[SCROLL:...]`.
+///
+/// `actions` is in the order Claude emitted the tags, so they can be
+/// executed sequentially.
+struct CompoundActionParseResult {
+    /// Response text with ALL tags stripped — what gets spoken.
+    let spokenText: String
+    /// Pointing tag (if any) — drives the existing cursor-flight animation.
+    let pointResult: PointingParseResult
+    /// Action tags in source order, ready to feed into LocalIntentExecutor.
+    let actions: [LocalIntent]
+}
+
+/// Namespace for parsing structured tags Claude embeds in its responses.
+/// Behaviour is intentionally identical to the previous implementation that
+/// lived as `CompanionManager.parsePointingCoordinates` — this is a phase 1
+/// relocation only, no logic changes.
+enum ActionTagParser {
+
+    /// Parses a [POINT:x,y:label:screenN] or [POINT:none] tag from the end of Claude's response.
+    /// Returns the spoken text (tag removed) and the optional coordinate + label + screen number.
+    static func parsePointingCoordinates(from responseText: String) -> PointingParseResult {
+        // Match [POINT:none] or [POINT:123,456:label] or [POINT:123,456:label:screen2]
+        let pattern = #"\[POINT:(?:none|(\d+)\s*,\s*(\d+)(?::([^\]:\s][^\]:]*?))?(?::screen(\d+))?)\]\s*$"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []),
+              let match = regex.firstMatch(in: responseText, range: NSRange(responseText.startIndex..., in: responseText)) else {
+            // No tag found at all
+            return PointingParseResult(
+                spokenText: responseText.trimmingCharacters(in: .whitespacesAndNewlines),
+                coordinate: nil,
+                elementLabel: nil,
+                screenNumber: nil
+            )
+        }
+
+        // Remove the tag from the spoken text
+        let tagRange = Range(match.range, in: responseText)!
+        let spokenText = String(responseText[..<tagRange.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Check if it's [POINT:none]
+        guard match.numberOfRanges >= 3,
+              let xRange = Range(match.range(at: 1), in: responseText),
+              let yRange = Range(match.range(at: 2), in: responseText),
+              let x = Double(responseText[xRange]),
+              let y = Double(responseText[yRange]) else {
+            return PointingParseResult(spokenText: spokenText, coordinate: nil, elementLabel: "none", screenNumber: nil)
+        }
+
+        var elementLabel: String? = nil
+        if match.numberOfRanges >= 4, let labelRange = Range(match.range(at: 3), in: responseText) {
+            elementLabel = String(responseText[labelRange]).trimmingCharacters(in: .whitespaces)
+        }
+
+        var screenNumber: Int? = nil
+        if match.numberOfRanges >= 5, let screenRange = Range(match.range(at: 4), in: responseText) {
+            screenNumber = Int(responseText[screenRange])
+        }
+
+        return PointingParseResult(
+            spokenText: spokenText,
+            coordinate: CGPoint(x: x, y: y),
+            elementLabel: elementLabel,
+            screenNumber: screenNumber
+        )
+    }
+
+    // MARK: - Compound action tags
+
+    /// Parses every supported tag from Claude's response and returns:
+    /// 1) the cleaned-up text to speak,
+    /// 2) the optional pointing result (existing flow),
+    /// 3) the sequence of executable LocalIntent actions.
+    ///
+    /// Tags supported: [OPEN_APP:Name], [QUIT_APP:Name], [CLICK:Target],
+    /// [TYPE:Literal text], [KEY:cmd+s], [SCROLL:up|down|left|right],
+    /// plus the existing [POINT:x,y:label].
+    static func parseAllActionTags(from responseText: String) -> CompoundActionParseResult {
+        let nsResponse = responseText as NSString
+        var actionMatches: [(range: NSRange, intent: LocalIntent)] = []
+
+        // Each pattern captures the tag's argument in group 1. The argument
+        // may contain anything except `]`, which means the inner brackets
+        // would break parsing — Claude is told in the prompt not to use
+        // brackets inside tag values.
+        let patterns: [(name: String, regex: String)] = [
+            ("OPEN_APP", #"\[OPEN_APP:([^\]]+)\]"#),
+            ("QUIT_APP", #"\[QUIT_APP:([^\]]+)\]"#),
+            ("CLICK", #"\[CLICK:([^\]]+)\]"#),
+            ("TYPE", #"\[TYPE:([^\]]+)\]"#),
+            ("KEY", #"\[KEY:([^\]]+)\]"#),
+            ("SCROLL", #"\[SCROLL:([^\]]+)\]"#),
+        ]
+
+        for (tagName, regexPattern) in patterns {
+            // Case-insensitive — Claude's "all lowercase casual" style means
+            // it might emit [open_app:freeform] instead of [OPEN_APP:Freeform].
+            // Both are valid; the parser shouldn't care.
+            guard let regex = try? NSRegularExpression(pattern: regexPattern, options: [.caseInsensitive]) else { continue }
+            let allMatches = regex.matches(
+                in: responseText,
+                range: NSRange(location: 0, length: nsResponse.length)
+            )
+            for match in allMatches {
+                guard match.numberOfRanges >= 2 else { continue }
+                let argument = nsResponse
+                    .substring(with: match.range(at: 1))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !argument.isEmpty else { continue }
+                if let intent = makeIntent(forTagName: tagName, argument: argument) {
+                    actionMatches.append((range: match.range, intent: intent))
+                }
+            }
+        }
+
+        // Sort by source position so tags execute in the order Claude wrote
+        // them ("[OPEN_APP:Notes] [CLICK:New Note] [TYPE:hello]").
+        actionMatches.sort { $0.range.location < $1.range.location }
+
+        // Strip every action tag from the response, working back-to-front
+        // so the indices we collected stay valid as we delete.
+        let mutableText = NSMutableString(string: responseText)
+        for range in actionMatches.map({ $0.range }).sorted(by: { $0.location > $1.location }) {
+            mutableText.replaceCharacters(in: range, with: "")
+        }
+        let textWithActionTagsRemoved = mutableText as String
+
+        // Now run the existing point parser on the action-cleaned text.
+        let pointResult = parsePointingCoordinates(from: textWithActionTagsRemoved)
+
+        return CompoundActionParseResult(
+            spokenText: pointResult.spokenText,
+            pointResult: pointResult,
+            actions: actionMatches.map { $0.intent }
+        )
+    }
+
+    /// Maps a tag name + raw argument string to a typed `LocalIntent`.
+    /// Returns nil for malformed arguments (e.g. an unknown scroll direction)
+    /// so we silently drop them rather than executing junk.
+    private static func makeIntent(forTagName tagName: String, argument: String) -> LocalIntent? {
+        switch tagName {
+        case "OPEN_APP":
+            return .launchOrActivateApp(name: argument)
+        case "QUIT_APP":
+            return .quitApp(name: argument)
+        case "CLICK":
+            return .clickByName(targetName: argument)
+        case "TYPE":
+            // Preserve whatever casing/whitespace Claude emitted inside [TYPE:...]
+            return .typeText(text: argument)
+        case "KEY":
+            return .pressKeyChord(chord: argument.lowercased())
+        case "SCROLL":
+            switch argument.lowercased() {
+            case "up": return .scroll(direction: .up)
+            case "down": return .scroll(direction: .down)
+            case "left": return .scroll(direction: .left)
+            case "right": return .scroll(direction: .right)
+            default: return nil
+            }
+        default:
+            return nil
+        }
+    }
+}

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -74,16 +74,16 @@ final class CompanionManager: ObservableObject {
     private lazy var claudeAPI: any AnthropicChatClient = {
         // Use the claude CLI subprocess so no separate Anthropic API key is needed.
         if ClaudeCodeCLIClient.isAvailable() {
-            print("✅ Using Claude Code CLI subprocess for responses")
+            FileLogger.log("✅ Using Claude Code CLI subprocess for responses")
             return ClaudeCodeCLIClient(model: selectedModel)
         }
 
         if let proxyURL = Self.configuredClaudeProxyURL() {
-            print("⚠️ Claude Code CLI not found — using configured Worker proxy")
+            FileLogger.log("⚠️ Claude Code CLI not found — using configured Worker proxy")
             return ClaudeAPI(authMode: .proxyURL(proxyURL), model: selectedModel)
         }
 
-        print("⚠️ Claude Code CLI not found and no Worker proxy configured — using Claude Code OAuth direct API")
+        FileLogger.log("⚠️ Claude Code CLI not found and no Worker proxy configured — using Claude Code OAuth direct API")
         return ClaudeAPI(authMode: .claudeCodeOAuth, model: selectedModel)
     }()
 
@@ -129,6 +129,7 @@ final class CompanionManager: ObservableObject {
     /// The currently running AI response task, if any. Cancelled when the user
     /// speaks again so a new response can begin immediately.
     private var currentResponseTask: Task<Void, Never>?
+    private var currentTurnStartDate: Date?
 
     private var shortcutTransitionCancellable: AnyCancellable?
     private var voiceStateCancellable: AnyCancellable?
@@ -150,12 +151,29 @@ final class CompanionManager: ObservableObject {
     @Published private(set) var isOverlayVisible: Bool = false
 
     /// The Claude model used for voice responses. Persisted to UserDefaults.
-    @Published var selectedModel: String = UserDefaults.standard.string(forKey: "selectedClaudeModel") ?? "claude-sonnet-4-6"
+    @Published var selectedModel: String = Self.initialSelectedModel()
 
     func setSelectedModel(_ model: String) {
         selectedModel = model
         UserDefaults.standard.set(model, forKey: "selectedClaudeModel")
+        UserDefaults.standard.set(true, forKey: "hasExplicitlySelectedClaudeModel")
         claudeAPI.model = model
+    }
+
+    private static func initialSelectedModel() -> String {
+        let defaults = UserDefaults.standard
+        let fastModel = "claude-haiku-4-5-20251001"
+        guard let storedModel = defaults.string(forKey: "selectedClaudeModel") else {
+            return fastModel
+        }
+        // Migrate the old launch default from Sonnet to Fast. If the user picks
+        // Sonnet from the menu after this build, the explicit-selection flag
+        // preserves that choice.
+        if storedModel == "claude-sonnet-4-6",
+           defaults.bool(forKey: "hasExplicitlySelectedClaudeModel") == false {
+            return fastModel
+        }
+        return storedModel
     }
 
     /// User preference for whether the Clicky cursor should be shown.
@@ -601,7 +619,7 @@ final class CompanionManager: ObservableObject {
                     },
                     submitDraftText: { [weak self] finalTranscript in
                         self?.lastTranscript = finalTranscript
-                        print("🗣️ Companion received transcript: \(finalTranscript)")
+                        FileLogger.log("🗣️ Companion received transcript: \(finalTranscript)")
                         ClickyAnalytics.trackUserMessageSent(transcript: finalTranscript)
                         self?.sendTranscriptToClaudeWithScreenshot(transcript: finalTranscript)
                     }
@@ -645,6 +663,12 @@ final class CompanionManager: ObservableObject {
     - focus on giving a thorough, useful explanation. don't end with simple yes/no questions like "want me to explain more?" or "should i show you?" — those are dead ends that force the user to just say yes.
     - instead, when it fits naturally, end by planting a seed — mention something bigger or more ambitious they could try, a related concept that goes deeper, or a next-level technique that builds on what you just explained. make it something worth coming back for, not a question they'd just nod to. it's okay to not end with anything extra if the answer is complete on its own.
     - if you receive multiple screen images, the one labeled "primary focus" is where the cursor is — prioritize that one but reference others if relevant.
+
+    mac actions:
+    when the user asks you to do something on their mac, emit action tags instead of only talking. tags execute in order:
+    [OPEN_APP:Notes], [QUIT_APP:Safari], [CLICK:File], [TYPE:hello], [KEY:cmd+s], [SCROLL:down].
+    for example, if they say "make a note about pasta tonight", respond with [OPEN_APP:Notes] [KEY:cmd+n] [TYPE:pasta tonight].
+    keep any spoken words short; if the tags fully do the task, you can output only tags.
 
     element pointing:
     you have a small blue triangle cursor that can fly to and point at things on screen. use it whenever pointing would genuinely help the user — if they're asking how to do something, looking for a menu, trying to find a button, or need help navigating an app, point at the relevant element. err on the side of pointing rather than not pointing, because it makes your help way more useful and concrete.
@@ -741,6 +765,39 @@ final class CompanionManager: ObservableObject {
         return true
     }
 
+    private func routeTranscriptToLocalIntentIfNeeded(_ transcript: String) async -> Bool {
+        let localIntent = LocalIntentRouter.route(transcript: transcript)
+        guard localIntent != .unmatched else {
+            FileLogger.log("🎯 LocalIntentRouter: unmatched (transcript: \"\(transcript)\") — falling to Claude")
+            return false
+        }
+
+        FileLogger.log("🎯 LocalIntentRouter matched: \(localIntent) (transcript: \"\(transcript)\")")
+        switch await LocalIntentExecutor.execute(localIntent) {
+        case .succeeded(let spokenAcknowledgement):
+            let assistantResponse = spokenAcknowledgement.isEmpty
+                ? "(executed: \(localIntent))"
+                : spokenAcknowledgement
+            conversationHistory.append((userTranscript: transcript, assistantResponse: assistantResponse))
+            if conversationHistory.count > 10 {
+                conversationHistory.removeFirst(conversationHistory.count - 10)
+            }
+            memoryManager.onTurnCompleted(userTranscript: transcript, assistantResponse: assistantResponse)
+
+            if !spokenAcknowledgement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                speakWithMacOSVoice(spokenAcknowledgement)
+                voiceState = .responding
+            } else {
+                voiceState = .idle
+            }
+            scheduleTransientHideIfNeeded()
+            return true
+        case .failed(let reason):
+            FileLogger.log("⚠️ LocalIntent fell through: \(reason)")
+            return false
+        }
+    }
+
     // MARK: - AI Response Pipeline
 
     /// Captures a screenshot, sends it along with the transcript to Claude,
@@ -757,14 +814,21 @@ final class CompanionManager: ObservableObject {
         currentResponseTask = Task {
             // Stay in processing (spinner) state — no streaming text displayed
             voiceState = .processing
+            currentTurnStartDate = Date()
+            logPipelinePhase("turn started")
 
             do {
                 if await routeTranscriptToCodexIfNeeded(transcript) {
                     return
                 }
 
+                if await routeTranscriptToLocalIntentIfNeeded(transcript) {
+                    return
+                }
+
                 // Capture all connected screens so the AI has full context
                 let screenCaptures = try await CompanionScreenCaptureUtility.captureAllScreensAsJPEG()
+                logPipelinePhase("screenshots captured (\(screenCaptures.count))")
 
                 guard !Task.isCancelled else { return }
 
@@ -791,21 +855,41 @@ final class CompanionManager: ObservableObject {
                     return transcript
                 }()
 
+                var didReceiveFirstChunk = false
                 let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
                     images: labeledImages,
                     systemPrompt: companionVoiceResponseSystemPromptWithMemory,
                     conversationHistory: historyForAPI,
                     userPrompt: userPromptWithAppContext,
-                    onTextChunk: { _ in
+                    onTextChunk: { [weak self] _ in
                         // No streaming text display — spinner stays until TTS plays
+                        if !didReceiveFirstChunk {
+                            didReceiveFirstChunk = true
+                            self?.logPipelinePhase("first stream chunk")
+                        }
                     }
                 )
 
                 guard !Task.isCancelled else { return }
 
-                // Parse the [POINT:...] tag from Claude's response
-                let parseResult = Self.parsePointingCoordinates(from: fullResponseText)
-                let spokenText = parseResult.spokenText
+                logPipelinePhase("stream complete (\(fullResponseText.count) chars)")
+                FileLogger.log("📝 Claude raw response:\n  ┌─\n  │ \(fullResponseText.replacingOccurrences(of: "\n", with: "\n  │ "))\n  └─")
+
+                // Parse pointing plus native action tags, then execute actions.
+                let compoundResult = ActionTagParser.parseAllActionTags(from: fullResponseText)
+                FileLogger.log("📝 Parsed \(compoundResult.actions.count) action tags from response")
+                let parseResult = compoundResult.pointResult
+                let spokenText = compoundResult.spokenText
+
+                for action in compoundResult.actions {
+                    let executionResult = await LocalIntentExecutor.execute(action)
+                    switch executionResult {
+                    case .succeeded:
+                        FileLogger.log("⚡️ Claude action executed: \(action)")
+                    case .failed(let reason):
+                        FileLogger.log("⚠️ Claude action failed: \(action) — \(reason)")
+                    }
+                }
 
                 // Handle element pointing if Claude returned coordinates.
                 // Switch to idle BEFORE setting the location so the triangle
@@ -940,6 +1024,16 @@ final class CompanionManager: ObservableObject {
     private func speakCreditsErrorFallback() {
         speakWithMacOSVoice("Sorry, something went wrong. Please try again.")
         voiceState = .responding
+    }
+
+    private func logPipelinePhase(_ phaseName: String) {
+        let elapsedMs: Int
+        if let currentTurnStartDate {
+            elapsedMs = Int(Date().timeIntervalSince(currentTurnStartDate) * 1000)
+        } else {
+            elapsedMs = 0
+        }
+        FileLogger.log("⏱️ [+\(elapsedMs)ms] \(phaseName)")
     }
 
     /// Speaks text via `/usr/bin/say` in a separate process so it cannot

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -151,7 +151,7 @@ final class CompanionManager: ObservableObject {
     @Published private(set) var isOverlayVisible: Bool = false
 
     /// The Claude model used for voice responses. Persisted to UserDefaults.
-    @Published var selectedModel: String = Self.initialSelectedModel()
+    @Published var selectedModel: String = CompanionManager.initialSelectedModel()
 
     func setSelectedModel(_ model: String) {
         selectedModel = model

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -607,6 +607,7 @@ struct CompanionPanelView: View {
             Spacer()
 
             HStack(spacing: 0) {
+                modelOptionButton(label: "Fast", modelID: "claude-haiku-4-5-20251001")
                 modelOptionButton(label: "Sonnet", modelID: "claude-sonnet-4-6")
                 modelOptionButton(label: "Opus", modelID: "claude-opus-4-6")
             }

--- a/leanring-buddy/FileLogger.swift
+++ b/leanring-buddy/FileLogger.swift
@@ -1,0 +1,69 @@
+//
+//  FileLogger.swift
+//  leanring-buddy
+//
+//  Mirrors the most important diagnostic prints to ~/Desktop/clicky.log
+//  so we can `tail -f` from a Terminal window and see exactly what the
+//  app is doing in real time, without needing to wrestle Xcode's
+//  cramped debug console.
+//
+//  Anything passed to FileLogger.log() ALSO prints to stdout, so Xcode
+//  console output is unchanged. The file write is async on a serial
+//  queue so logging never blocks the main thread.
+//
+
+import Foundation
+
+enum FileLogger {
+    private static let logFileURL: URL = {
+        let desktop = FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory() + "/Desktop")
+        return desktop.appendingPathComponent("clicky.log")
+    }()
+
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        return formatter
+    }()
+
+    private static let writeQueue = DispatchQueue(label: "com.clicky.filelogger")
+
+    /// Lazily ensures the log file exists. Called once on first log call.
+    private static let bootstrap: Void = {
+        let separator = "\n========================================\n"
+            + "==== SESSION START \(ISO8601DateFormatter().string(from: Date())) ====\n"
+            + "========================================\n"
+        appendStringToLogFile(separator)
+        return ()
+    }()
+
+    /// Logs a message to both stdout (Xcode console) and ~/Desktop/clicky.log.
+    static func log(_ message: String) {
+        // Always print so Xcode console is unaffected for users who can read it.
+        print(message)
+
+        // Async write to file so this never blocks the caller.
+        _ = bootstrap
+        let timestamp = timestampFormatter.string(from: Date())
+        let line = "[\(timestamp)] \(message)\n"
+        writeQueue.async {
+            appendStringToLogFile(line)
+        }
+    }
+
+    private static func appendStringToLogFile(_ text: String) {
+        guard let data = text.data(using: .utf8) else { return }
+        let url = logFileURL
+        if FileManager.default.fileExists(atPath: url.path) {
+            if let handle = try? FileHandle(forWritingTo: url) {
+                defer { try? handle.close() }
+                _ = try? handle.seekToEnd()
+                try? handle.write(contentsOf: data)
+                return
+            }
+        }
+        // Create file (or overwrite if FileHandle failed for some reason).
+        try? data.write(to: url, options: .atomic)
+    }
+}

--- a/leanring-buddy/LocalIntentExecutor.swift
+++ b/leanring-buddy/LocalIntentExecutor.swift
@@ -1,0 +1,538 @@
+//
+//  LocalIntentExecutor.swift
+//  leanring-buddy
+//
+//  Runs LocalIntent values via macOS-native APIs (NSWorkspace, AXUIElement,
+//  CGEvent). Designed for sub-200ms latency — no network, no LLM, no TTS
+//  round-trip. The visible action IS the user feedback for most intents.
+//
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+@MainActor
+enum LocalIntentExecutor {
+
+    /// Result of attempting an intent.
+    enum ExecutionResult {
+        /// Intent ran successfully — caller should skip the LLM.
+        /// `spokenAcknowledgement` is non-empty only when the intent's whole
+        /// purpose IS to speak (e.g. .currentTime). For action intents we
+        /// leave it empty because the visible action is the feedback.
+        case succeeded(spokenAcknowledgement: String)
+        /// Intent didn't run — caller falls back to the LLM with the
+        /// original transcript.
+        case failed(reason: String)
+    }
+
+    static func execute(_ intent: LocalIntent) async -> ExecutionResult {
+        switch intent {
+        case .launchOrActivateApp(let name):
+            return await launchOrActivateApp(named: name)
+        case .quitApp(let name):
+            return quitApp(named: name)
+        case .clickByName(let name):
+            // Brief settle pause so click lands AFTER any preceding launch
+            // has actually focused its window. Cheap insurance for chains.
+            try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
+            return clickElementByName(name)
+        case .typeText(let text):
+            // Same insurance — typing into a window that hasn't focused yet
+            // is the most common multi-action chain failure.
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            return typeText(text)
+        case .pressKeyChord(let chord):
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            return pressKeyChord(chord)
+        case .scroll(let direction):
+            return scroll(direction: direction)
+        case .currentTime:
+            return .succeeded(spokenAcknowledgement: spokenCurrentTime())
+        case .unmatched:
+            return .failed(reason: "no local intent matched")
+        }
+    }
+
+    // MARK: - App launch / activate
+
+    private static func launchOrActivateApp(named requestedName: String) async -> ExecutionResult {
+        // Fast path: app already running — just activate. macOS makes this
+        // synchronous with the next action: by the time activate() returns,
+        // the app's main window is the key window.
+        let lowercaseRequested = requestedName.lowercased()
+        if let runningApp = NSWorkspace.shared.runningApplications.first(where: {
+            ($0.localizedName ?? "").lowercased() == lowercaseRequested
+        }) {
+            runningApp.activate(options: [.activateAllWindows])
+            FileLogger.log("⚡️ LocalIntent: activate \"\(runningApp.localizedName ?? requestedName)\"")
+            await waitForAppToBecomeFrontmost(matching: runningApp.localizedName ?? requestedName, timeoutSeconds: 1.0)
+            return .succeeded(spokenAcknowledgement: "")
+        }
+
+        // Disk lookup. `fullPath(forApplication:)` is technically deprecated
+        // but is the only by-name lookup that works without a bundle ID.
+        for candidate in casingCandidates(for: requestedName) {
+            if let appPath = NSWorkspace.shared.fullPath(forApplication: candidate) {
+                return await launchAppAt(URL(fileURLWithPath: appPath), label: candidate)
+            }
+        }
+
+        // Fuzzy fallback: voice transcripts get app names slightly wrong
+        // ("feeform" instead of "Freeform"). Search the installed-app cache
+        // for the closest match within a tight Levenshtein distance.
+        if let fuzzyMatch = closestInstalledAppName(to: requestedName),
+           let appPath = NSWorkspace.shared.fullPath(forApplication: fuzzyMatch) {
+            FileLogger.log("🔍 LocalIntent: fuzzy-matched \"\(requestedName)\" → \"\(fuzzyMatch)\"")
+            return await launchAppAt(URL(fileURLWithPath: appPath), label: fuzzyMatch)
+        }
+
+        return .failed(reason: "no app named \(requestedName) found")
+    }
+
+    /// Helper that runs the actual NSWorkspace open with the standard config
+    /// and waits for the launched app to actually become frontmost so any
+    /// chained subsequent actions land in the right window.
+    private static func launchAppAt(_ url: URL, label: String) async -> ExecutionResult {
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            NSWorkspace.shared.openApplication(at: url, configuration: configuration) { _, error in
+                if let error {
+                    FileLogger.log("⚠️ LocalIntent: openApplication failed for \(label): \(error)")
+                }
+                continuation.resume()
+            }
+        }
+        FileLogger.log("⚡️ LocalIntent: launch \"\(label)\"")
+
+        // Critical for chained actions like Notes→cmd+n→type: don't return
+        // until the app is actually frontmost, otherwise the next action's
+        // CGEvent goes to the wrong window.
+        await waitForAppToBecomeFrontmost(matching: label, timeoutSeconds: 2.5)
+        return .succeeded(spokenAcknowledgement: "")
+    }
+
+    /// Polls every 50ms until the frontmost app's name matches `label` (case
+    /// insensitive, partial match either way), or the timeout elapses.
+    /// Typical app activation completes in 200-500ms so the timeout is
+    /// generous; we exit early on success.
+    private static func waitForAppToBecomeFrontmost(matching label: String, timeoutSeconds: Double) async {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        let normalizedLabel = label.lowercased()
+        while Date() < deadline {
+            if let frontmostApp = NSWorkspace.shared.frontmostApplication,
+               let frontmostName = frontmostApp.localizedName?.lowercased() {
+                if frontmostName == normalizedLabel
+                    || frontmostName.contains(normalizedLabel)
+                    || normalizedLabel.contains(frontmostName) {
+                    // Tiny extra settle so the window is really key, not just
+                    // the process being foregrounded.
+                    try? await Task.sleep(nanoseconds: 80_000_000)  // 80ms
+                    return
+                }
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)  // 50ms poll
+        }
+        FileLogger.log("⚠️ Timeout (\(timeoutSeconds)s) waiting for \"\(label)\" to become frontmost")
+    }
+
+    /// Scans /Applications, /System/Applications, and ~/Applications once
+    /// per process and caches the list. Used for fuzzy name matching when
+    /// the user's spoken app name doesn't exactly match what's installed.
+    private static let installedAppNamesCache: [String] = {
+        let appDirectories = [
+            "/Applications",
+            "/System/Applications",
+            "/System/Applications/Utilities",
+            NSHomeDirectory() + "/Applications",
+        ]
+        let fileManager = FileManager.default
+        var collectedAppNames: Set<String> = []
+        for directory in appDirectories {
+            guard let entries = try? fileManager.contentsOfDirectory(atPath: directory) else { continue }
+            for entry in entries where entry.hasSuffix(".app") {
+                let appName = String(entry.dropLast(".app".count))
+                if !appName.isEmpty {
+                    collectedAppNames.insert(appName)
+                }
+            }
+        }
+        return collectedAppNames.sorted()
+    }()
+
+    /// Finds the installed app whose name is closest to `requestedName`,
+    /// returning nil if no app is within the acceptable similarity bound.
+    /// Tunable: ~30% character distance is generous enough for ASR typos
+    /// like "feeform"→"Freeform" while strict enough to reject unrelated
+    /// transcripts ("explain html" → no match).
+    private static func closestInstalledAppName(to requestedName: String) -> String? {
+        let normalizedRequested = requestedName.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedRequested.isEmpty else { return nil }
+
+        var bestMatch: (name: String, distance: Int)? = nil
+
+        for installedName in installedAppNamesCache {
+            let distance = levenshteinDistance(normalizedRequested, installedName.lowercased())
+            if bestMatch == nil || distance < bestMatch!.distance {
+                bestMatch = (installedName, distance)
+            }
+        }
+
+        guard let match = bestMatch else { return nil }
+
+        // Accept only matches within ~30% character distance, with a floor
+        // of 1 for very short names (so 1-char typos in 3-char names work).
+        let maxAllowedDistance = max(1, normalizedRequested.count * 3 / 10)
+        return match.distance <= maxAllowedDistance ? match.name : nil
+    }
+
+    /// Standard Wagner-Fischer Levenshtein distance.
+    private static func levenshteinDistance(_ a: String, _ b: String) -> Int {
+        let aChars = Array(a)
+        let bChars = Array(b)
+        if aChars.isEmpty { return bChars.count }
+        if bChars.isEmpty { return aChars.count }
+
+        var distanceMatrix = Array(
+            repeating: Array(repeating: 0, count: bChars.count + 1),
+            count: aChars.count + 1
+        )
+        for i in 0...aChars.count { distanceMatrix[i][0] = i }
+        for j in 0...bChars.count { distanceMatrix[0][j] = j }
+        for i in 1...aChars.count {
+            for j in 1...bChars.count {
+                if aChars[i - 1] == bChars[j - 1] {
+                    distanceMatrix[i][j] = distanceMatrix[i - 1][j - 1]
+                } else {
+                    distanceMatrix[i][j] = 1 + min(
+                        distanceMatrix[i - 1][j],
+                        distanceMatrix[i][j - 1],
+                        distanceMatrix[i - 1][j - 1]
+                    )
+                }
+            }
+        }
+        return distanceMatrix[aChars.count][bChars.count]
+    }
+
+    private static func casingCandidates(for name: String) -> [String] {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var candidates: [String] = [trimmed]
+        let titleCased = trimmed
+            .split(separator: " ")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst().lowercased() }
+            .joined(separator: " ")
+        if titleCased != trimmed {
+            candidates.append(titleCased)
+        }
+
+        let knownCasings: [String: String] = [
+            "vs code": "Visual Studio Code",
+            "vscode": "Visual Studio Code",
+            "intellij": "IntelliJ IDEA",
+            "iterm": "iTerm",
+            "iterm2": "iTerm",
+            "imovie": "iMovie",
+            "preview": "Preview",
+            "safari": "Safari",
+            "freeform": "Freeform",
+            "x code": "Xcode",
+            "xcode": "Xcode",
+            "chrome": "Google Chrome",
+            "firefox": "Firefox",
+        ]
+        if let known = knownCasings[trimmed.lowercased()] {
+            candidates.append(known)
+        }
+
+        var seen = Set<String>()
+        return candidates.filter { seen.insert($0).inserted }
+    }
+
+    private static func quitApp(named requestedName: String) -> ExecutionResult {
+        let lowercaseRequested = requestedName.lowercased()
+        for runningApp in NSWorkspace.shared.runningApplications {
+            guard let localizedName = runningApp.localizedName else { continue }
+            if localizedName.lowercased() == lowercaseRequested {
+                if runningApp.terminate() {
+                    FileLogger.log("⚡️ LocalIntent: quit \"\(localizedName)\"")
+                    return .succeeded(spokenAcknowledgement: "")
+                } else {
+                    return .failed(reason: "\(localizedName) refused to quit")
+                }
+            }
+        }
+        return .failed(reason: "no running app named \(requestedName)")
+    }
+
+    // MARK: - Generic click via AX tree walk
+
+    /// Walks the frontmost app's accessibility tree looking for any element
+    /// whose title matches `targetName` (case-insensitively, exact match
+    /// preferred, prefix match second, substring match last). Calls
+    /// AXPress on the best match. ~10-50ms for typical apps.
+    ///
+    /// "apple" / "apple menu" is special-cased to mean "first menu bar item"
+    /// because the Apple menu has no title in AX.
+    private static func clickElementByName(_ targetName: String) -> ExecutionResult {
+        guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
+            return .failed(reason: "no frontmost app")
+        }
+        let appElement = AXUIElementCreateApplication(frontmostApp.processIdentifier)
+        let normalizedTarget = targetName.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Strip a trailing UI-noun suffix so "file menu" matches an
+        // AXMenuBarItem titled "File", and "save button" matches a button
+        // titled "Save".
+        let strippedTarget = stripUINounSuffix(normalizedTarget)
+
+        // Apple menu special case: empty title, always at index 0 of menu bar.
+        if strippedTarget == "apple" {
+            if let menuBar = axCopyAttribute(appElement, attribute: kAXMenuBarAttribute),
+               CFGetTypeID(menuBar) == AXUIElementGetTypeID(),
+               let children = axCopyAttribute(menuBar as! AXUIElement, attribute: kAXChildrenAttribute) as? [AXUIElement],
+               let appleMenu = children.first {
+                if AXUIElementPerformAction(appleMenu, kAXPressAction as CFString) == .success {
+                    FileLogger.log("⚡️ LocalIntent: click Apple menu in \(frontmostApp.localizedName ?? "?")")
+                    return .succeeded(spokenAcknowledgement: "")
+                }
+            }
+            return .failed(reason: "could not press Apple menu (accessibility permission?)")
+        }
+
+        // Generic walk — find best-scoring titled element.
+        var bestMatch: (element: AXUIElement, score: Double, title: String, role: String)? = nil
+        walkAccessibilityTree(appElement, depth: 0, maxDepth: 10) { element in
+            let title = (axCopyAttribute(element, attribute: kAXTitleAttribute) as? String) ?? ""
+            let titleLower = title.lowercased()
+            guard !titleLower.isEmpty else { return }
+
+            var score: Double = 0
+            if titleLower == strippedTarget {
+                score = 100
+            } else if titleLower.hasPrefix(strippedTarget + " ") || titleLower.hasPrefix(strippedTarget) {
+                score = 70
+            } else if titleLower.contains(strippedTarget) {
+                score = 40
+            } else {
+                return
+            }
+
+            // Boost interactive roles so we prefer a button labeled "Save"
+            // over a static text labeled "Save".
+            let role = (axCopyAttribute(element, attribute: kAXRoleAttribute) as? String) ?? ""
+            let interactiveRoles: Set<String> = [
+                "AXButton", "AXMenuItem", "AXMenuBarItem", "AXMenu",
+                "AXLink", "AXCheckBox", "AXRadioButton", "AXPopUpButton",
+                "AXTabGroup", "AXSwitch",
+            ]
+            if interactiveRoles.contains(role) {
+                score += 15
+            }
+
+            if bestMatch == nil || score > bestMatch!.score {
+                bestMatch = (element, score, title, role)
+            }
+        }
+
+        guard let match = bestMatch else {
+            return .failed(reason: "no element titled \"\(targetName)\" in \(frontmostApp.localizedName ?? "frontmost app")")
+        }
+
+        let pressStatus = AXUIElementPerformAction(match.element, kAXPressAction as CFString)
+        if pressStatus == .success {
+            FileLogger.log("⚡️ LocalIntent: click \"\(match.title)\" (\(match.role)) in \(frontmostApp.localizedName ?? "?")")
+            return .succeeded(spokenAcknowledgement: "")
+        } else {
+            return .failed(reason: "AX press failed on \"\(match.title)\" (status=\(pressStatus.rawValue))")
+        }
+    }
+
+    private static func stripUINounSuffix(_ text: String) -> String {
+        let suffixes = [" menu", " button", " tab", " window", " panel", " link", " field", " checkbox"]
+        for suffix in suffixes {
+            if text.hasSuffix(suffix) {
+                return String(text.dropLast(suffix.count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        return text
+    }
+
+    /// Bounded depth-first walk of the AX tree, calling `visit` on each
+    /// element. We follow children, visible-children, and the menu-bar
+    /// pseudo-attribute (since menu bars aren't always linked from the
+    /// regular children list).
+    private static func walkAccessibilityTree(
+        _ root: AXUIElement,
+        depth: Int,
+        maxDepth: Int,
+        visit: (AXUIElement) -> Void
+    ) {
+        guard depth <= maxDepth else { return }
+        visit(root)
+
+        let childAttributes = [
+            kAXChildrenAttribute,
+            kAXVisibleChildrenAttribute,
+            kAXMenuBarAttribute,
+        ]
+        for attribute in childAttributes {
+            guard let value = axCopyAttribute(root, attribute: attribute) else { continue }
+
+            if let array = value as? [AXUIElement] {
+                for child in array {
+                    walkAccessibilityTree(child, depth: depth + 1, maxDepth: maxDepth, visit: visit)
+                }
+            } else if CFGetTypeID(value) == AXUIElementGetTypeID() {
+                walkAccessibilityTree(value as! AXUIElement, depth: depth + 1, maxDepth: maxDepth, visit: visit)
+            }
+        }
+    }
+
+    private static func axCopyAttribute(_ element: AXUIElement, attribute: String) -> AnyObject? {
+        var ref: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(element, attribute as CFString, &ref)
+        guard status == .success else { return nil }
+        return ref
+    }
+
+    // MARK: - Type text via CGEvent
+
+    /// Types a literal string at the current keyboard focus by synthesizing
+    /// per-character key events with `CGEventKeyboardSetUnicodeString`.
+    /// Handles arbitrary Unicode (emoji, accented chars, CJK).
+    private static func typeText(_ text: String) -> ExecutionResult {
+        guard !text.isEmpty else { return .failed(reason: "empty type text") }
+        for character in text {
+            postUnicodeKeyEvent(for: String(character))
+        }
+        FileLogger.log("⚡️ LocalIntent: type \"\(text.prefix(80))\(text.count > 80 ? "…" : "")\"")
+        return .succeeded(spokenAcknowledgement: "")
+    }
+
+    private static func postUnicodeKeyEvent(for substring: String) {
+        let utf16 = Array(substring.utf16)
+        guard let downEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true) else { return }
+        utf16.withUnsafeBufferPointer { buffer in
+            if let baseAddress = buffer.baseAddress {
+                downEvent.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: baseAddress)
+            }
+        }
+        downEvent.post(tap: .cghidEventTap)
+
+        guard let upEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) else { return }
+        utf16.withUnsafeBufferPointer { buffer in
+            if let baseAddress = buffer.baseAddress {
+                upEvent.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: baseAddress)
+            }
+        }
+        upEvent.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - Key chord via CGEvent
+
+    /// Posts a chord like "cmd+s" or "cmd+shift+t" or just "return".
+    private static func pressKeyChord(_ chord: String) -> ExecutionResult {
+        let parts = chord.lowercased().split(separator: "+").map { String($0) }
+        guard let keyName = parts.last else { return .failed(reason: "empty chord") }
+        let modifierNames = parts.dropLast()
+
+        guard let keyCode = virtualKeyCode(for: keyName) else {
+            return .failed(reason: "unknown key \"\(keyName)\" in chord \"\(chord)\"")
+        }
+
+        var flags: CGEventFlags = []
+        for modifierName in modifierNames {
+            switch modifierName {
+            case "cmd":   flags.insert(.maskCommand)
+            case "ctrl":  flags.insert(.maskControl)
+            case "opt":   flags.insert(.maskAlternate)
+            case "shift": flags.insert(.maskShift)
+            case "fn":    flags.insert(.maskSecondaryFn)
+            default:      return .failed(reason: "unknown modifier \"\(modifierName)\"")
+            }
+        }
+
+        guard let downEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true),
+              let upEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
+            return .failed(reason: "could not create key event for \(chord)")
+        }
+
+        downEvent.flags = flags
+        upEvent.flags = flags
+        downEvent.post(tap: .cghidEventTap)
+        upEvent.post(tap: .cghidEventTap)
+        FileLogger.log("⚡️ LocalIntent: press \(chord)")
+        return .succeeded(spokenAcknowledgement: "")
+    }
+
+    /// US-keyboard virtual key codes for the keys we recognize.
+    private static func virtualKeyCode(for key: String) -> CGKeyCode? {
+        if let code = singleCharKeyCode[key] { return code }
+        if let code = namedKeyCode[key] { return code }
+        return nil
+    }
+
+    private static let singleCharKeyCode: [String: CGKeyCode] = [
+        "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7,
+        "c": 8, "v": 9, "b": 11, "q": 12, "w": 13, "e": 14, "r": 15,
+        "y": 16, "t": 17, "1": 18, "2": 19, "3": 20, "4": 21, "6": 22,
+        "5": 23, "=": 24, "9": 25, "7": 26, "-": 27, "8": 28, "0": 29,
+        "]": 30, "o": 31, "u": 32, "[": 33, "i": 34, "p": 35,
+        "l": 37, "j": 38, "'": 39, "k": 40, ";": 41, "\\": 42, ",": 43,
+        "/": 44, "n": 45, "m": 46, ".": 47, "`": 50,
+    ]
+
+    private static let namedKeyCode: [String: CGKeyCode] = [
+        "return": 36, "enter": 36, "tab": 48, "space": 49, "spacebar": 49,
+        "delete": 51, "backspace": 51, "forward delete": 117,
+        "escape": 53, "esc": 53,
+        "left": 123, "right": 124, "down": 125, "up": 126,
+        "home": 115, "end": 119, "pageup": 116, "pagedown": 121,
+        "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96, "f6": 97,
+        "f7": 98, "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
+    ]
+
+    // MARK: - Scroll via CGEvent
+
+    private static func scroll(direction: ScrollDirection) -> ExecutionResult {
+        // ~120px per call, roughly 4 lines of text. Multiple calls for more.
+        let pixelDelta: Int32 = 120
+        let (verticalDelta, horizontalDelta): (Int32, Int32) = {
+            switch direction {
+            case .up: return (pixelDelta, 0)
+            case .down: return (-pixelDelta, 0)
+            case .left: return (0, pixelDelta)
+            case .right: return (0, -pixelDelta)
+            }
+        }()
+
+        guard let event = CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: verticalDelta,
+            wheel2: horizontalDelta,
+            wheel3: 0
+        ) else {
+            return .failed(reason: "could not create scroll event")
+        }
+        event.post(tap: .cghidEventTap)
+        FileLogger.log("⚡️ LocalIntent: scroll \(direction)")
+        return .succeeded(spokenAcknowledgement: "")
+    }
+
+    // MARK: - Current time
+
+    private static func spokenCurrentTime() -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return "it's \(formatter.string(from: Date()))"
+    }
+}

--- a/leanring-buddy/LocalIntentRouter.swift
+++ b/leanring-buddy/LocalIntentRouter.swift
@@ -1,0 +1,607 @@
+//
+//  LocalIntentRouter.swift
+//  leanring-buddy
+//
+//  Recognizes voice transcripts as deterministic Mac actions and dispatches
+//  them via macOS-native APIs in ~50-200ms — no LLM, no screenshot, no
+//  TTS round-trip. The grammar is verb-driven and intentionally GENERAL:
+//  "click X" / "type X" / "press X" / "scroll up" / "open X" all work for
+//  arbitrary X, not a hardcoded enumeration.
+//
+//  Anything we can't classify deterministically falls through to the
+//  existing Claude pipeline so the user always gets some response.
+//
+
+import Foundation
+
+/// Direction of a scroll-wheel synthesis.
+enum ScrollDirection: Equatable {
+    case up
+    case down
+    case left
+    case right
+}
+
+/// One concrete action that can be executed locally without a Claude call.
+enum LocalIntent: Equatable {
+    /// Launch the named app (or activate it if already running).
+    case launchOrActivateApp(name: String)
+    /// Send a graceful Quit to the named app.
+    case quitApp(name: String)
+    /// Click any element in the frontmost app's accessibility tree whose
+    /// title matches `targetName`. Generic — covers menu bar items, buttons,
+    /// menu items, links, checkboxes, anything labeled.
+    case clickByName(targetName: String)
+    /// Type a literal string at the current keyboard focus.
+    case typeText(text: String)
+    /// Synthesize a key chord (modifiers + a single key) at the current focus.
+    /// `chord` is the human-readable form, e.g. "cmd+s", "cmd+shift+t".
+    case pressKeyChord(chord: String)
+    /// Scroll the wheel at the current cursor position.
+    case scroll(direction: ScrollDirection)
+    /// Speak the current local time.
+    case currentTime
+    /// No fast path — caller falls through to the LLM pipeline.
+    case unmatched
+}
+
+enum LocalIntentRouter {
+
+    // MARK: - Public entry point
+
+    static func route(transcript: String) -> LocalIntent {
+        let normalized = normalize(transcript)
+        guard !normalized.isEmpty else { return .unmatched }
+
+        // Order: most-specific first so e.g. "scroll up" doesn't get
+        // misparsed as a generic verb-object pair.
+
+        if let direction = scrollDirection(from: normalized) {
+            return .scroll(direction: direction)
+        }
+
+        if isCurrentTimeQuery(normalized) {
+            return .currentTime
+        }
+
+        // "navigate to <X>" / "go to the <X> icon" / "show me the <X> menu"
+        // — these are click intents on UI elements, not app launches. Match
+        // them BEFORE the loose-app-command parser so "go to apple icon"
+        // doesn't get mis-routed as launching an app called "apple icon".
+        if let navTargetName = parseNavigateOrShowCommand(normalized) {
+            return .clickByName(targetName: navTargetName)
+        }
+
+        // LOOSE WORD-ORDER MATCHING for app commands. Voice transcripts often
+        // come back with the verb at the end ("freeform open", "safari please")
+        // or no verb at all (just the bare app name). Rather than enumerate
+        // every word order, we scan the words for any open/quit/switch verb
+        // and treat the rest as the app name.
+        //
+        // This runs BEFORE the strict verb-prefix matcher because a strict
+        // match for "open" with junk after it would otherwise pre-empt this.
+        if let looseAppIntent = parseLooseAppCommand(normalized) {
+            return looseAppIntent
+        }
+
+        if let (verb, remainder) = splitLeadingVerb(in: normalized) {
+            switch verb {
+            case .click:
+                if !remainder.isEmpty {
+                    return .clickByName(targetName: remainder)
+                }
+            case .type:
+                if !remainder.isEmpty {
+                    return .typeText(text: preserveOriginalCasing(of: remainder, from: transcript))
+                }
+            case .press, .hit:
+                // "press" / "hit" is ambiguous — could be a key chord
+                // ("press cmd s") or a click target ("press the save
+                // button"). Disambiguate by checking if the remainder
+                // starts with a modifier word or names a known key.
+                if let chord = parseKeyChord(remainder) {
+                    return .pressKeyChord(chord: chord)
+                }
+                if !remainder.isEmpty {
+                    return .clickByName(targetName: remainder)
+                }
+            case .open:
+                // "open" is also ambiguous — could be an app launch
+                // ("open Freeform") or a UI element click ("open the file
+                // menu"). If the remainder ends with a UI noun ("menu",
+                // "tab", "window", "panel"), treat as click. Otherwise
+                // assume app.
+                if endsWithUIElementNoun(remainder) {
+                    return .clickByName(targetName: remainder)
+                }
+                if !remainder.isEmpty {
+                    return .launchOrActivateApp(name: remainder)
+                }
+            case .launch, .start:
+                if !remainder.isEmpty {
+                    return .launchOrActivateApp(name: remainder)
+                }
+            case .switchTo, .focusOn, .goTo:
+                if !remainder.isEmpty {
+                    return .launchOrActivateApp(name: remainder)
+                }
+            case .quit, .close, .exit:
+                if !remainder.isEmpty {
+                    return .quitApp(name: remainder)
+                }
+            }
+        }
+
+        return .unmatched
+    }
+
+    // MARK: - Verb table
+
+    private enum Verb {
+        case click
+        case type
+        case press
+        case hit
+        case open
+        case launch
+        case start
+        case switchTo
+        case focusOn
+        case goTo
+        case quit
+        case close
+        case exit
+    }
+
+    /// Ordered longest-prefix-first so e.g. "switch to " matches before "switch ".
+    private static let verbPrefixes: [(prefix: String, verb: Verb)] = [
+        ("switch over to ", .switchTo),
+        ("switch to ", .switchTo),
+        ("focus on ", .focusOn),
+        ("go to ", .goTo),
+        ("click on ", .click),
+        ("click the ", .click),
+        ("click ", .click),
+        ("tap on ", .click),
+        ("tap the ", .click),
+        ("tap ", .click),
+        ("select the ", .click),
+        ("select ", .click),
+        ("press the ", .press),
+        ("press ", .press),
+        ("hit the ", .hit),
+        ("hit ", .hit),
+        ("type out ", .type),
+        ("type in ", .type),
+        ("type ", .type),
+        ("write out ", .type),
+        ("write ", .type),
+        ("open the ", .open),
+        ("open ", .open),
+        ("launch ", .launch),
+        ("start ", .start),
+        ("boot up ", .launch),
+        ("fire up ", .launch),
+        ("quit ", .quit),
+        ("close ", .close),
+        ("exit ", .exit),
+        ("kill ", .quit),
+        ("shut down ", .quit),
+        ("bring up ", .switchTo),
+    ]
+
+    /// Returns the matched verb and the cleaned-up remainder (target/text/chord).
+    private static func splitLeadingVerb(in normalized: String) -> (Verb, String)? {
+        for (prefix, verb) in verbPrefixes {
+            if normalized.hasPrefix(prefix) {
+                let remainder = String(normalized.dropFirst(prefix.count))
+                let cleaned = stripTrailingFillerAndPunctuation(stripDeterminerPrefix(remainder))
+                return (verb, cleaned)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Loose word-order app command parsing
+
+    /// Common verbs that mean "launch/activate this app", regardless of
+    /// where they appear in the sentence.
+    private static let looseLaunchVerbWords: Set<String> = [
+        "open", "launch", "start", "boot", "run", "fire",
+    ]
+    /// Common verbs that mean "quit this app".
+    private static let looseQuitVerbWords: Set<String> = [
+        "quit", "close", "exit", "kill",
+    ]
+    /// Filler words that should be discarded when extracting the app name.
+    private static let looseAppCommandFillerWords: Set<String> = [
+        "the", "my", "this", "that", "an", "a",
+        "please", "now", "for", "me",
+        "uh", "um", "umm", "uhh",
+        "up", "down",  // "boot up", "shut down"
+        "to", "of",
+        "app", "application", "program",
+    ]
+
+    /// Tries to recognize an app-launch / app-quit intent regardless of word
+    /// order. Returns nil if the transcript doesn't contain a launch/quit
+    /// verb word.
+    ///
+    /// Examples that this matches but the strict verb-prefix matcher would not:
+    ///   "freeform open"        → launchOrActivateApp("freeform")
+    ///   "open up freeform"     → launchOrActivateApp("freeform")
+    ///   "please open freeform" → launchOrActivateApp("freeform")  (wrappers
+    ///                            stripped by normalize, but extra defense)
+    ///   "freeform quit"        → quitApp("freeform")
+    private static func parseLooseAppCommand(_ text: String) -> LocalIntent? {
+        let words = text
+            .split(whereSeparator: { $0.isWhitespace || ",.!?—-".contains($0) })
+            .map(String.init)
+        guard !words.isEmpty else { return nil }
+
+        // Find the verb word's position so we can ignore noise on the WRONG
+        // side of it. Real-world example: "Wiki, open Freeform, the app on
+        // my Mac" — "Wiki" is wake-word noise that came BEFORE the verb,
+        // and shouldn't be part of the app name.
+        var detectedVerb: LooseAppVerb? = nil
+        var verbWordIndex: Int? = nil
+        for (index, word) in words.enumerated() {
+            let lowercased = word.lowercased()
+            if looseLaunchVerbWords.contains(lowercased) {
+                detectedVerb = .launch
+                verbWordIndex = index
+                break
+            }
+            if looseQuitVerbWords.contains(lowercased) {
+                detectedVerb = .quit
+                verbWordIndex = index
+                break
+            }
+        }
+
+        guard let verb = detectedVerb, let verbIndex = verbWordIndex else { return nil }
+
+        // Words AFTER the verb are the app name, unless the verb is at the
+        // very end (e.g. "freeform open") in which case the words BEFORE
+        // the verb are the app name.
+        let candidateNameWords: ArraySlice<String>
+        if verbIndex + 1 < words.count {
+            candidateNameWords = words[(verbIndex + 1)...]
+        } else if verbIndex > 0 {
+            candidateNameWords = words[..<verbIndex]
+        } else {
+            return nil
+        }
+
+        // Stop app-name capture at a clause boundary. Speech transcripts often
+        // include a cut-off tail like "open Google for me and—"; without this,
+        // the app name becomes "google and" and misses the fast path.
+        let boundedNameWords = candidateNameWords.prefix { word in
+            !["and", "then", "but"].contains(word.lowercased())
+        }
+
+        // Drop pure filler tokens but keep substantive words.
+        let filteredNameWords = boundedNameWords.filter {
+            !looseAppCommandFillerWords.contains($0.lowercased())
+        }
+        let rawJoinedName = filteredNameWords.joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Strip "on my mac" / "on the screen" / "for me" tails that voice
+        // users append after the actual app name.
+        let cleanedAppName = stripTrailingContextPhrases(rawJoinedName)
+        guard !cleanedAppName.isEmpty else { return nil }
+
+        switch verb {
+        case .launch:
+            return .launchOrActivateApp(name: cleanedAppName)
+        case .quit:
+            return .quitApp(name: cleanedAppName)
+        }
+    }
+
+    private enum LooseAppVerb {
+        case launch
+        case quit
+    }
+
+    /// Recognizes "navigate to <X>", "go to the <X> icon", "show me the <X>
+    /// menu" and similar phrasings, returning the bare element name. These
+    /// are CLICK intents (not app launches) because the user is referring
+    /// to a UI element on screen, usually with a UI-noun suffix (icon, menu,
+    /// button, tab, etc.).
+    ///
+    /// Returns nil if the transcript doesn't begin with a navigate/show verb.
+    private static func parseNavigateOrShowCommand(_ text: String) -> String? {
+        let navigateVerbs: [String] = [
+            "navigate to ", "navigate to the ", "navigate to my ",
+            "show me the ", "show me my ",
+            "go to the ", "go to my ",
+            "to the ", "to my ",
+        ]
+        var matchedVerbPrefix: String? = nil
+        for verbPrefix in navigateVerbs {
+            if text.hasPrefix(verbPrefix) {
+                matchedVerbPrefix = verbPrefix
+                break
+            }
+        }
+        guard let verbPrefix = matchedVerbPrefix else { return nil }
+
+        let remainder = String(text.dropFirst(verbPrefix.count))
+        let cleaned = stripTrailingFillerAndPunctuation(remainder)
+        // Drop trailing context like " on my mac" / " on my screen" that
+        // people add to voice commands but isn't part of the target name.
+        let stripped = stripTrailingContextPhrases(cleaned)
+        // Drop trailing UI noun ("icon" / "menu" / "button") — clickByName
+        // does that itself, but doing it here makes the matched name cleaner.
+        let withoutNoun = stripTrailingUINoun(stripped)
+        return withoutNoun.isEmpty ? nil : withoutNoun
+    }
+
+    /// Strips noisy trailing phrases voice users often append: " on my mac",
+    /// " on the screen", " right now", etc. Anything that doesn't refer to
+    /// a real target.
+    private static func stripTrailingContextPhrases(_ text: String) -> String {
+        var result = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trailers = [
+            " on my mac", " on my screen", " on the screen", " on screen",
+            " on mac", " on the mac",
+            " on this app", " on this", " in this app",
+            " right now", " for me", " thanks", " thank you",
+        ]
+        var changed = true
+        while changed {
+            changed = false
+            for trailer in trailers {
+                if result.hasSuffix(trailer) {
+                    result = String(result.dropLast(trailer.count))
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    changed = true
+                    break
+                }
+            }
+        }
+        return result
+    }
+
+    /// Drops a trailing UI-noun word so "apple icon" → "apple", "file menu"
+    /// → "file". `clickByName` already does this in the executor, but doing
+    /// it here keeps the matched intent name cleaner in logs.
+    private static func stripTrailingUINoun(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let suffixes = [" icon", " menu", " button", " tab", " window", " panel", " link", " field", " checkbox"]
+        for suffix in suffixes {
+            if trimmed.hasSuffix(suffix) {
+                return String(trimmed.dropLast(suffix.count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        return trimmed
+    }
+
+    // MARK: - Scroll matching
+
+    private static func scrollDirection(from text: String) -> ScrollDirection? {
+        let stripped = stripTrailingFillerAndPunctuation(text)
+        switch stripped {
+        case "scroll up", "scroll upward", "scroll upwards", "page up":
+            return .up
+        case "scroll down", "scroll downward", "scroll downwards", "page down":
+            return .down
+        case "scroll left":
+            return .left
+        case "scroll right":
+            return .right
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Key chord parsing
+
+    private static let modifierWords: Set<String> = [
+        "cmd", "command", "ctrl", "control", "opt", "option", "alt",
+        "shift", "fn", "function",
+    ]
+
+    private static let namedKeys: Set<String> = [
+        "return", "enter", "escape", "esc", "space", "spacebar", "tab",
+        "up", "down", "left", "right",
+        "delete", "backspace", "forward delete",
+        "home", "end", "pageup", "pagedown",
+        "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+        "f11", "f12",
+    ]
+
+    /// Parses things like:
+    ///   "cmd s"        → "cmd+s"
+    ///   "command s"    → "cmd+s"
+    ///   "command shift t" → "cmd+shift+t"
+    ///   "return"       → "return"
+    /// Returns nil if the input doesn't look like a key chord.
+    private static func parseKeyChord(_ text: String) -> String? {
+        let words = text
+            .lowercased()
+            .replacingOccurrences(of: "+", with: " ")
+            .split(separator: " ")
+            .map { String($0) }
+            .filter { !$0.isEmpty }
+        guard !words.isEmpty else { return nil }
+
+        var modifiers: [String] = []
+        var keyName: String? = nil
+
+        for word in words {
+            if modifierWords.contains(word) {
+                modifiers.append(canonicalModifier(word))
+            } else if namedKeys.contains(word) || word.count == 1 {
+                // Single-character keys ("s", "t", etc.) plus named keys
+                // ("return", "escape", "f1", etc.) are valid chord targets.
+                guard keyName == nil else { return nil }  // two key names → not a chord
+                keyName = word
+            } else {
+                // Unknown token in a chord position — bail out so this is
+                // treated as a click target instead.
+                return nil
+            }
+        }
+
+        guard let key = keyName else { return nil }
+
+        // De-dup modifiers while preserving canonical order.
+        let canonicalOrder = ["cmd", "ctrl", "opt", "shift", "fn"]
+        let uniqueMods = canonicalOrder.filter { modifiers.contains($0) }
+
+        if uniqueMods.isEmpty {
+            return key  // bare key like "return"
+        }
+        return uniqueMods.joined(separator: "+") + "+" + key
+    }
+
+    private static func canonicalModifier(_ word: String) -> String {
+        switch word {
+        case "command", "cmd": return "cmd"
+        case "control", "ctrl": return "ctrl"
+        case "option", "opt", "alt": return "opt"
+        case "shift": return "shift"
+        case "function", "fn": return "fn"
+        default: return word
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func endsWithUIElementNoun(_ text: String) -> Bool {
+        let nouns = [" menu", " tab", " window", " panel", " sidebar", " toolbar", " dialog", " popup", " dropdown"]
+        for noun in nouns {
+            if text.hasSuffix(noun) { return true }
+        }
+        return false
+    }
+
+    private static func stripDeterminerPrefix(_ text: String) -> String {
+        var result = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let determiners = ["the ", "my ", "this ", "that ", "an ", "a "]
+        for det in determiners {
+            if result.hasPrefix(det) {
+                result = String(result.dropFirst(det.count))
+                break
+            }
+        }
+        return result
+    }
+
+    /// Looks up the normalized substring in the original transcript and
+    /// returns the casing-preserved version. Used so "type Hello World"
+    /// doesn't get downcased to "hello world" before being typed out.
+    private static func preserveOriginalCasing(of normalizedRemainder: String, from originalTranscript: String) -> String {
+        let lowercaseOriginal = originalTranscript.lowercased()
+        guard let range = lowercaseOriginal.range(of: normalizedRemainder) else {
+            return normalizedRemainder
+        }
+        // Map the lowercased range back to the original transcript's indices.
+        let startOffset = lowercaseOriginal.distance(from: lowercaseOriginal.startIndex, to: range.lowerBound)
+        let length = lowercaseOriginal.distance(from: range.lowerBound, to: range.upperBound)
+        let originalStart = originalTranscript.index(originalTranscript.startIndex, offsetBy: startOffset)
+        let originalEnd = originalTranscript.index(originalStart, offsetBy: length)
+        return String(originalTranscript[originalStart..<originalEnd])
+    }
+
+    /// Lowercases, trims, and removes filler/wake-word prefixes so a noisy
+    /// transcript like "Um, hey clicky, can you click the file menu, please?"
+    /// becomes "click the file menu" for matching.
+    private static func normalize(_ transcript: String) -> String {
+        var result = transcript
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let leadingFillers: [String] = [
+            "um ", "uh ", "uhh ", "umm ", "okay ", "ok ", "alright ",
+            "please ", "hey ", "hi ", "yo ", "yeah ",
+            "clicky ", "clikie ", "clicky, ", "clicky.",
+            "buddy ", "learning buddy ", "learning buddy, ",
+            "leanring buddy ", "leanring buddy, ",
+        ]
+
+        var changed = true
+        while changed {
+            changed = false
+            for filler in leadingFillers {
+                if result.hasPrefix(filler) {
+                    result = String(result.dropFirst(filler.count))
+                    changed = true
+                    break
+                }
+            }
+            while let first = result.first, ",.!?".contains(first) {
+                result = String(result.dropFirst())
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                changed = true
+            }
+        }
+
+        let politenessWrappers = [
+            "can you ", "could you ", "would you ", "please can you ",
+            "i want to ", "i'd like to ", "i'd like you to ", "i need to ",
+            "let's ", "lets ",
+        ]
+        for wrapper in politenessWrappers {
+            if result.hasPrefix(wrapper) {
+                result = String(result.dropFirst(wrapper.count))
+                break
+            }
+        }
+
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func stripTrailingFillerAndPunctuation(_ text: String) -> String {
+        var result = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        while let last = result.last, ",.!?".contains(last) {
+            result = String(result.dropLast())
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        let trailers = [" for me", " please", " now", " right now", " thanks", " thank you"]
+        var changed = true
+        while changed {
+            changed = false
+            for trailer in trailers {
+                if result.hasSuffix(trailer) {
+                    result = String(result.dropLast(trailer.count))
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    changed = true
+                    break
+                }
+                if result.hasSuffix("," + trailer) {
+                    result = String(result.dropLast(trailer.count + 1))
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    changed = true
+                    break
+                }
+            }
+        }
+
+        while let last = result.last, ",.!?".contains(last) {
+            result = String(result.dropLast())
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return result
+    }
+
+    private static func isCurrentTimeQuery(_ text: String) -> Bool {
+        let stripped = stripTrailingFillerAndPunctuation(text)
+        let timePhrases: Set<String> = [
+            "what time is it",
+            "what's the time",
+            "what is the time",
+            "current time",
+            "tell me the time",
+            "give me the time",
+            "the time",
+        ]
+        return timePhrases.contains(stripped)
+    }
+}

--- a/leanring-buddyTests/leanring_buddyTests.swift
+++ b/leanring-buddyTests/leanring_buddyTests.swift
@@ -59,4 +59,31 @@ struct leanring_buddyTests {
         #expect(tasks[1].contains("Parallel Codex session 2"))
     }
 
+    @Test func localIntentCleansCutOffAppLaunchSpeech() async throws {
+        let intent = LocalIntentRouter.route(transcript: "Can you open up Google for me and—")
+
+        #expect(intent == .launchOrActivateApp(name: "google"))
+    }
+
+    @Test func localIntentDropsInlineSpeechFillerFromAppName() async throws {
+        let intent = LocalIntentRouter.route(transcript: "Open, uh, Freeform.")
+
+        #expect(intent == .launchOrActivateApp(name: "freeform"))
+    }
+
+    @Test func localIntentRoutesBareContinuationToClickTarget() async throws {
+        let intent = LocalIntentRouter.route(transcript: "to the Apple icon.")
+
+        #expect(intent == .clickByName(targetName: "apple"))
+    }
+
+    @Test func actionOnlyResponseHasNoSpokenWhitespace() async throws {
+        let parsed = ActionTagParser.parseAllActionTags(
+            from: "[OPEN_APP:Notes] [KEY:cmd+n] [TYPE:pasta tonight]"
+        )
+
+        #expect(parsed.actions.count == 3)
+        #expect(parsed.spokenText == "")
+    }
+
 }


### PR DESCRIPTION
## Summary
- Restore the native local intent router/executor so common Mac actions skip Claude entirely.
- Add Claude action-tag parsing/execution for fallback turns, so Claude can do actions instead of only talking.
- Add file timing logs back to `~/Desktop/clicky.log` for real latency debugging from Xcode runs.
- Add a Fast model option and migrate the old default voice model from Sonnet to Haiku for lower latency.
- Add regression tests for cut-off/filler speech like `open up Google for me and—`, `Open, uh, Freeform`, and `to the Apple icon`.

## Why
The main branch still routed most normal voice actions through the Claude subprocess, which creates multi-second silence before anything visible happens. Local deterministic commands should complete in roughly 50-300ms and only fall back to Claude when the command is not safely classifiable.

## Validation
- `git diff --check`
- `xcrun swiftc -parse leanring-buddy/FileLogger.swift leanring-buddy/LocalIntentRouter.swift leanring-buddy/LocalIntentExecutor.swift leanring-buddy/ActionTagParser.swift leanring-buddy/CompanionManager.swift leanring-buddy/CompanionPanelView.swift leanring-buddy/CodexCLIClient.swift leanring-buddyTests/leanring_buddyTests.swift`
- `xcrun swiftc -typecheck leanring-buddy/FileLogger.swift leanring-buddy/LocalIntentRouter.swift leanring-buddy/LocalIntentExecutor.swift leanring-buddy/ActionTagParser.swift`
- Local Swift harness for router/action-tag behavior

Note: local `xcodebuild` was intentionally not run because this repo warns it can invalidate macOS TCC permissions.