### PR TITLE
[codex] Resolve Xcode warning noise

### DIFF
--- a/leanring-buddy.xcodeproj/project.pbxproj
+++ b/leanring-buddy.xcodeproj/project.pbxproj
@@ -34,9 +34,22 @@
 		28F22CD62F56440300A0FC59 /* leanring-buddyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "leanring-buddyUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		C0DE00012F76000100000001 /* Exceptions for "leanring-buddy" folder in "leanring-buddy" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 28F22CBE2F56440300A0FC59 /* leanring-buddy */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		28F22CC12F56440300A0FC59 /* leanring-buddy */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				C0DE00012F76000100000001 /* Exceptions for "leanring-buddy" folder in "leanring-buddy" target */,
+			);
 			path = "leanring-buddy";
 			sourceTree = "<group>";
 		};

--- a/leanring-buddy/AgentSessionDetailWindow.swift
+++ b/leanring-buddy/AgentSessionDetailWindow.swift
@@ -280,7 +280,7 @@ struct AgentSessionDetailView: View {
         ScrollView {
             ScrollViewReader { proxy in
                 outputAreaContent
-                    .onChange(of: session.liveOutput) { _ in
+                    .onChange(of: session.liveOutput) { _, _ in
                         withAnimation(.easeOut(duration: 0.15)) {
                             proxy.scrollTo("output", anchor: .bottom)
                         }

--- a/leanring-buddy/AgentSiblingsOverlayWindow.swift
+++ b/leanring-buddy/AgentSiblingsOverlayWindow.swift
@@ -140,7 +140,7 @@ struct AgentSiblingsContainerView: View {
                 onSessionsEmpty()
             }
         }
-        .onChange(of: sessionManager.sessions.count) { count in
+        .onChange(of: sessionManager.sessions.count) { _, count in
             if count == 0 {
                 onSessionsEmpty()
             }

--- a/leanring-buddy/AssemblyAIStreamingTranscriptionProvider.swift
+++ b/leanring-buddy/AssemblyAIStreamingTranscriptionProvider.swift
@@ -140,7 +140,7 @@ final class AssemblyAIStreamingTranscriptionProvider: BuddyTranscriptionProvider
     }
 }
 
-private final class AssemblyAIStreamingTranscriptionSession: NSObject, BuddyStreamingTranscriptionSession {
+private final class AssemblyAIStreamingTranscriptionSession: NSObject, BuddyStreamingTranscriptionSession, @unchecked Sendable {
     private struct MessageEnvelope: Decodable {
         let type: String
     }
@@ -406,9 +406,9 @@ private final class AssemblyAIStreamingTranscriptionSession: NSObject, BuddyStre
         explicitFinalTranscriptDeadlineWorkItem?.cancel()
 
         let deadlineWorkItem = DispatchWorkItem { [weak self] in
-            self?.stateQueue.async {
-                guard let self else { return }
-                self.deliverFinalTranscriptIfNeeded(self.bestAvailableTranscriptText())
+            guard let session = self else { return }
+            session.stateQueue.async {
+                session.deliverFinalTranscriptIfNeeded(session.bestAvailableTranscriptText())
             }
         }
 

--- a/leanring-buddy/ClaudeAPI.swift
+++ b/leanring-buddy/ClaudeAPI.swift
@@ -36,10 +36,23 @@ enum ClaudeAuthMode {
     }
 }
 
+private final class ClaudeAPITLSWarmupState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hasStarted = false
+
+    func markStartedIfNeeded() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !hasStarted else { return false }
+        hasStarted = true
+        return true
+    }
+}
+
 /// Claude API helper with streaming for progressive text display.
 class ClaudeAPI: AnthropicChatClient {
-    private static let tlsWarmupLock = NSLock()
-    private static var hasStartedTLSWarmup = false
+    private static let tlsWarmupState = ClaudeAPITLSWarmupState()
 
     private let authMode: ClaudeAuthMode
     var model: String
@@ -109,14 +122,7 @@ class ClaudeAPI: AnthropicChatClient {
     /// Sends a no-op HEAD request to the API host to establish and cache a TLS session.
     /// Failures are silently ignored — this is purely an optimization.
     private func warmUpTLSConnectionIfNeeded() {
-        Self.tlsWarmupLock.lock()
-        let shouldStartTLSWarmup = !Self.hasStartedTLSWarmup
-        if shouldStartTLSWarmup {
-            Self.hasStartedTLSWarmup = true
-        }
-        Self.tlsWarmupLock.unlock()
-
-        guard shouldStartTLSWarmup else { return }
+        guard Self.tlsWarmupState.markStartedIfNeeded() else { return }
 
         var warmupRequest = URLRequest(url: authMode.tlsWarmupURL)
         warmupRequest.httpMethod = "HEAD"

--- a/leanring-buddy/ClaudeCodeCLIClient.swift
+++ b/leanring-buddy/ClaudeCodeCLIClient.swift
@@ -26,6 +26,66 @@ enum ClaudeCodeCLIError: Error, LocalizedError {
     }
 }
 
+private final class ClaudeCodeCLIStreamState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hasResumed = false
+    private var accumulatedResponseText = ""
+    private var lineBuffer = ""
+
+    func appendStdoutChunk(_ chunk: String) -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        lineBuffer += chunk
+        var snapshots: [String] = []
+
+        while let newlineIndex = lineBuffer.firstIndex(of: "\n") {
+            let line = String(lineBuffer[lineBuffer.startIndex..<newlineIndex])
+            lineBuffer = String(lineBuffer[lineBuffer.index(after: newlineIndex)...])
+
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  let lineData = trimmed.data(using: .utf8),
+                  let event = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let eventType = event["type"] as? String
+            else { continue }
+
+            if eventType == "assistant",
+               let message = event["message"] as? [String: Any],
+               let contentArray = message["content"] as? [[String: Any]] {
+                let deltaText = contentArray.compactMap { block -> String? in
+                    guard block["type"] as? String == "text" else { return nil }
+                    return block["text"] as? String
+                }.joined()
+
+                if !deltaText.isEmpty {
+                    accumulatedResponseText += deltaText
+                    snapshots.append(accumulatedResponseText)
+                }
+            }
+
+            if eventType == "result",
+               accumulatedResponseText.isEmpty,
+               let resultText = event["result"] as? String,
+               !resultText.isEmpty {
+                accumulatedResponseText = resultText
+                snapshots.append(resultText)
+            }
+        }
+
+        return snapshots
+    }
+
+    func finishIfNeeded() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !hasResumed else { return nil }
+        hasResumed = true
+        return accumulatedResponseText
+    }
+}
+
 /// Calls the claude CLI subprocess using the user's Claude Code subscription.
 /// Supports vision (screenshots passed as base64 JSON) and streaming output.
 final class ClaudeCodeCLIClient: AnthropicChatClient {
@@ -138,59 +198,21 @@ final class ClaudeCodeCLIClient: AnthropicChatClient {
         stdinPipe.fileHandleForWriting.closeFile()
 
         return try await withCheckedThrowingContinuation { continuation in
-            var resumed = false
-            var accumulatedResponseText = ""
-            var lineBuffer = ""
+            let streamState = ClaudeCodeCLIStreamState()
 
             stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
                 guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
 
-                lineBuffer += chunk
-
-                // Process every complete newline-terminated JSON event
-                while let newlineIndex = lineBuffer.firstIndex(of: "\n") {
-                    let line = String(lineBuffer[lineBuffer.startIndex..<newlineIndex])
-                    lineBuffer = String(lineBuffer[lineBuffer.index(after: newlineIndex)...])
-
-                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty,
-                          let lineData = trimmed.data(using: .utf8),
-                          let event = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
-                          let eventType = event["type"] as? String
-                    else { continue }
-
-                    // assistant events carry partial or complete response text
-                    if eventType == "assistant",
-                       let message = event["message"] as? [String: Any],
-                       let contentArray = message["content"] as? [[String: Any]] {
-                        let deltaText = contentArray.compactMap { block -> String? in
-                            guard block["type"] as? String == "text" else { return nil }
-                            return block["text"] as? String
-                        }.joined()
-
-                        if !deltaText.isEmpty {
-                            accumulatedResponseText += deltaText
-                            let snapshot = accumulatedResponseText
-                            Task { @MainActor in await onTextChunk(snapshot) }
-                        }
-                    }
-
-                    // result event: fall back to its "result" field if we got no streaming text
-                    if eventType == "result",
-                       accumulatedResponseText.isEmpty,
-                       let resultText = event["result"] as? String,
-                       !resultText.isEmpty {
-                        accumulatedResponseText = resultText
-                        Task { @MainActor in await onTextChunk(resultText) }
-                    }
+                let snapshots = streamState.appendStdoutChunk(chunk)
+                for snapshot in snapshots {
+                    Task { @MainActor in onTextChunk(snapshot) }
                 }
             }
 
             process.terminationHandler = { terminatedProcess in
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                guard !resumed else { return }
-                resumed = true
+                guard let accumulatedResponseText = streamState.finishIfNeeded() else { return }
 
                 let duration = Date().timeIntervalSince(startTime)
                 if accumulatedResponseText.isEmpty {

--- a/leanring-buddy/CodexCLIClient.swift
+++ b/leanring-buddy/CodexCLIClient.swift
@@ -32,6 +32,173 @@ enum CodexCLIError: Error, LocalizedError {
     }
 }
 
+private struct CodexCLIStreamUpdate {
+    var threadIDs: [String] = []
+    var progressSnapshots: [String] = []
+    var errorMessage: String?
+}
+
+private final class CodexCLIStreamState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hasResumed = false
+    private var accumulatedResponseText = ""
+    private var lineBuffer = ""
+    private var stderrBuffer = ""
+
+    func appendStderrChunk(_ chunk: String) {
+        lock.lock()
+        stderrBuffer += chunk
+        lock.unlock()
+    }
+
+    func appendStdoutChunk(_ chunk: String) -> CodexCLIStreamUpdate {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !hasResumed else { return CodexCLIStreamUpdate() }
+
+        lineBuffer += chunk
+        var update = CodexCLIStreamUpdate()
+
+        while let newlineIndex = lineBuffer.firstIndex(of: "\n") {
+            let line = String(lineBuffer[lineBuffer.startIndex..<newlineIndex])
+            lineBuffer = String(lineBuffer[lineBuffer.index(after: newlineIndex)...])
+
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  let eventData = trimmed.data(using: .utf8),
+                  let event = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
+                  let eventType = event["type"] as? String
+            else { continue }
+
+            if eventType == "thread.started",
+               let threadID = event["thread_id"] as? String, !threadID.isEmpty {
+                update.threadIDs.append(threadID)
+            }
+
+            if (eventType == "output_text.delta" || eventType == "response.output_text.delta"),
+               let delta = event["delta"] as? String, !delta.isEmpty {
+                accumulatedResponseText += delta
+                update.progressSnapshots.append(accumulatedResponseText)
+            }
+
+            if eventType == "item.completed",
+               let item = event["item"] as? [String: Any],
+               let renderedText = renderCompletedItem(item) {
+                appendRenderedText(renderedText)
+                update.progressSnapshots.append(accumulatedResponseText)
+            }
+
+            if eventType == "error" || eventType == "turn.failed" {
+                hasResumed = true
+                update.errorMessage = Self.errorMessage(from: event)
+                break
+            }
+        }
+
+        return update
+    }
+
+    func finishIfNeeded(exitCode: Int32) -> Result<String, CodexCLIError>? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !hasResumed else { return nil }
+        hasResumed = true
+
+        if accumulatedResponseText.isEmpty {
+            let stderrSnippet = stderrBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !stderrSnippet.isEmpty {
+                let detail = String(stderrSnippet.suffix(500))
+                return .failure(.agentError("codex exit \(exitCode): \(detail)"))
+            }
+            return .failure(.noResponseReceived)
+        }
+
+        return .success(accumulatedResponseText)
+    }
+
+    private func appendRenderedText(_ text: String) {
+        if accumulatedResponseText.isEmpty {
+            accumulatedResponseText = text
+        } else {
+            accumulatedResponseText += "\n\n" + text
+        }
+    }
+
+    private func renderCompletedItem(_ item: [String: Any]) -> String? {
+        let itemType = item["type"] as? String ?? ""
+
+        switch itemType {
+        case "agent_message", "message":
+            if let text = item["text"] as? String, !text.isEmpty {
+                return text
+            }
+            if let contentArray = item["content"] as? [[String: Any]] {
+                let joined = contentArray.compactMap { block -> String? in
+                    guard let blockType = block["type"] as? String,
+                          blockType == "output_text" || blockType == "text" else { return nil }
+                    return block["text"] as? String
+                }.joined()
+                return joined.isEmpty ? nil : joined
+            }
+            return nil
+
+        case "command_execution", "shell_command":
+            let commandText: String? = {
+                if let command = item["command"] as? String { return command }
+                if let command = item["command"] as? [String] { return command.joined(separator: " ") }
+                return nil
+            }()
+            guard let commandText else { return nil }
+
+            var text = "$ \(commandText)"
+            if let output = item["aggregated_output"] as? String,
+               !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                text += "\n" + output.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            return text
+
+        case "file_change", "edit", "patch":
+            if let changes = item["changes"] as? [[String: Any]] {
+                let lines = changes.compactMap { change -> String? in
+                    guard let path = change["path"] as? String else { return nil }
+                    let kind = (change["kind"] as? String) ?? "edit"
+                    let icon: String = {
+                        switch kind {
+                        case "add": return "+"
+                        case "delete": return "-"
+                        default: return "edit"
+                        }
+                    }()
+                    return "\(icon) \(path)"
+                }
+                return lines.isEmpty ? nil : lines.joined(separator: "\n")
+            }
+            if let path = item["path"] as? String {
+                return "edit \(path)"
+            }
+            return nil
+
+        case "reasoning":
+            return nil
+
+        default:
+            if let text = item["text"] as? String, !text.isEmpty {
+                return "[\(itemType)] \(text)"
+            }
+            return nil
+        }
+    }
+
+    private static func errorMessage(from event: [String: Any]) -> String {
+        if let message = event["message"] as? String { return message }
+        if let error = event["error"] as? [String: Any],
+           let message = error["message"] as? String { return message }
+        return "Unknown Codex error"
+    }
+}
+
 /// Runs agent tasks using the Codex CLI bundled in /Applications/Clicky.app.
 /// Uses the Codex subscription stored at ~/.codex/auth.json — no API key needed.
 final class CodexCLIClient {
@@ -446,17 +613,14 @@ final class CodexCLIClient {
         Task { @MainActor in onProcessStarted(runningProcess) }
 
         return try await withCheckedThrowingContinuation { continuation in
-            var resumed = false
-            var accumulatedResponseText = ""
-            var lineBuffer = ""
-            var stderrBuffer = ""
+            let streamState = CodexCLIStreamState()
 
             // Capture stderr so we can surface real codex error messages when
             // the subprocess exits without producing usable JSONL on stdout.
             stderrPipe.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
                 guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
-                stderrBuffer += chunk
+                streamState.appendStderrChunk(chunk)
                 // Echo stderr to Xcode console too so the developer can see
                 // codex errors live during a session.
                 print("🟥 codex stderr: \(chunk.trimmingCharacters(in: .whitespacesAndNewlines))")
@@ -465,156 +629,32 @@ final class CodexCLIClient {
             stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
                 guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
-                lineBuffer += chunk
 
-                // Each JSONL event is newline-terminated
-                while let newlineIndex = lineBuffer.firstIndex(of: "\n") {
-                    let line = String(lineBuffer[lineBuffer.startIndex..<newlineIndex])
-                    lineBuffer = String(lineBuffer[lineBuffer.index(after: newlineIndex)...])
-
-                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty,
-                          let eventData = trimmed.data(using: .utf8),
-                          let event = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
-                          let eventType = event["type"] as? String
-                    else { continue }
-
-                    // thread.started — emit the codex thread/session ID so the
-                    // session can be resumed later for follow-up messages.
-                    if eventType == "thread.started",
-                       let threadID = event["thread_id"] as? String, !threadID.isEmpty {
-                        Task { @MainActor in await onThreadStarted(threadID) }
-                    }
-
-                    // Streaming text deltas — Codex streams partial output as it works
-                    if (eventType == "output_text.delta" || eventType == "response.output_text.delta"),
-                       let delta = event["delta"] as? String, !delta.isEmpty {
-                        accumulatedResponseText += delta
-                        let snapshot = accumulatedResponseText
-                        Task { @MainActor in await onProgressChunk(snapshot) }
-                    }
-
-                    // Completed item — codex emits these for agent messages,
-                    // tool calls (shell commands, file edits), and reasoning.
-                    // We surface them all so the panel shows what the agent
-                    // is doing in real time.
-                    if eventType == "item.completed",
-                       let item = event["item"] as? [String: Any] {
-                        let itemType = item["type"] as? String ?? ""
-                        var renderedText: String?
-
-                        switch itemType {
-                        case "agent_message", "message":
-                            // New shape: item.text directly (codex >= 0.124).
-                            // Old shape: item.content[].text (legacy).
-                            if let text = item["text"] as? String, !text.isEmpty {
-                                renderedText = text
-                            } else if let contentArray = item["content"] as? [[String: Any]] {
-                                let joined = contentArray.compactMap { block -> String? in
-                                    guard let blockType = block["type"] as? String,
-                                          blockType == "output_text" || blockType == "text" else { return nil }
-                                    return block["text"] as? String
-                                }.joined()
-                                if !joined.isEmpty { renderedText = joined }
-                            }
-
-                        case "command_execution", "shell_command":
-                            // Tool call running a shell command — show the
-                            // command and any aggregated stdout so the user
-                            // sees what codex is doing in real time.
-                            let cmd: String? = {
-                                if let s = item["command"] as? String { return s }
-                                if let arr = item["command"] as? [String] { return arr.joined(separator: " ") }
-                                return nil
-                            }()
-                            if let cmd {
-                                var text = "$ \(cmd)"
-                                if let output = item["aggregated_output"] as? String,
-                                   !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                                    text += "\n" + output.trimmingCharacters(in: .whitespacesAndNewlines)
-                                }
-                                renderedText = text
-                            }
-
-                        case "file_change", "edit", "patch":
-                            // Codex emits {path, kind} entries inside `changes`.
-                            // Older builds emitted top-level `path`. Handle both.
-                            if let changes = item["changes"] as? [[String: Any]] {
-                                let lines = changes.compactMap { change -> String? in
-                                    guard let path = change["path"] as? String else { return nil }
-                                    let kind = (change["kind"] as? String) ?? "edit"
-                                    let icon: String = {
-                                        switch kind {
-                                        case "add": return "+"
-                                        case "delete": return "−"
-                                        default: return "✎"
-                                        }
-                                    }()
-                                    return "\(icon) \(path)"
-                                }
-                                if !lines.isEmpty {
-                                    renderedText = lines.joined(separator: "\n")
-                                }
-                            } else if let path = item["path"] as? String {
-                                renderedText = "✎ \(path)"
-                            }
-
-                        case "reasoning":
-                            // Skip reasoning items — too noisy
-                            renderedText = nil
-
-                        default:
-                            // Unknown item type — log and surface text if any
-                            if let text = item["text"] as? String, !text.isEmpty {
-                                renderedText = "[\(itemType)] \(text)"
-                            }
-                        }
-
-                        if let text = renderedText {
-                            if accumulatedResponseText.isEmpty {
-                                accumulatedResponseText = text
-                            } else {
-                                accumulatedResponseText += "\n\n" + text
-                            }
-                            let snapshot = accumulatedResponseText
-                            Task { @MainActor in await onProgressChunk(snapshot) }
-                        }
-                    }
-
-                    // Error events — surface as thrown errors so CompanionManager can respond gracefully
-                    if eventType == "error" || eventType == "turn.failed" {
-                        let errorMessage: String = {
-                            if let msg = event["message"] as? String { return msg }
-                            if let errObj = event["error"] as? [String: Any],
-                               let msg = errObj["message"] as? String { return msg }
-                            return "Unknown Codex error"
-                        }()
-                        if !resumed {
-                            resumed = true
-                            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                            continuation.resume(throwing: CodexCLIError.agentError(errorMessage))
-                        }
-                    }
+                let update = streamState.appendStdoutChunk(chunk)
+                for threadID in update.threadIDs {
+                    Task { @MainActor in onThreadStarted(threadID) }
+                }
+                for snapshot in update.progressSnapshots {
+                    Task { @MainActor in onProgressChunk(snapshot) }
+                }
+                if let errorMessage = update.errorMessage {
+                    stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                    stderrPipe.fileHandleForReading.readabilityHandler = nil
+                    continuation.resume(throwing: CodexCLIError.agentError(errorMessage))
                 }
             }
 
             process.terminationHandler = { terminatedProcess in
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
                 stderrPipe.fileHandleForReading.readabilityHandler = nil
-                guard !resumed else { return }
-                resumed = true
-
-                if accumulatedResponseText.isEmpty {
-                    let stderrSnippet = stderrBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let exitCode = terminatedProcess.terminationStatus
-                    if !stderrSnippet.isEmpty {
-                        let detail = String(stderrSnippet.suffix(500))
-                        continuation.resume(throwing: CodexCLIError.agentError("codex exit \(exitCode): \(detail)"))
-                    } else {
-                        continuation.resume(throwing: CodexCLIError.noResponseReceived)
-                    }
-                } else {
+                guard let result = streamState.finishIfNeeded(exitCode: terminatedProcess.terminationStatus) else {
+                    return
+                }
+                switch result {
+                case .success(let accumulatedResponseText):
                     continuation.resume(returning: accumulatedResponseText)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
                 }
             }
         }
@@ -673,134 +713,41 @@ final class CodexCLIClient {
         Task { @MainActor in onProcessStarted(runningProcess) }
 
         return try await withCheckedThrowingContinuation { continuation in
-            var resumed = false
-            var accumulatedResponseText = ""
-            var lineBuffer = ""
-            var stderrBuffer = ""
+            let streamState = CodexCLIStreamState()
 
             stderrPipe.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
                 guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
-                stderrBuffer += chunk
+                streamState.appendStderrChunk(chunk)
                 print("🟥 codex stderr (resume): \(chunk.trimmingCharacters(in: .whitespacesAndNewlines))")
             }
 
             stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
                 guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
-                lineBuffer += chunk
 
-                while let newlineIndex = lineBuffer.firstIndex(of: "\n") {
-                    let line = String(lineBuffer[lineBuffer.startIndex..<newlineIndex])
-                    lineBuffer = String(lineBuffer[lineBuffer.index(after: newlineIndex)...])
-
-                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty,
-                          let eventData = trimmed.data(using: .utf8),
-                          let event = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
-                          let eventType = event["type"] as? String
-                    else { continue }
-
-                    if (eventType == "output_text.delta" || eventType == "response.output_text.delta"),
-                       let delta = event["delta"] as? String, !delta.isEmpty {
-                        accumulatedResponseText += delta
-                        let snapshot = accumulatedResponseText
-                        Task { @MainActor in await onProgressChunk(snapshot) }
-                    }
-
-                    if eventType == "item.completed",
-                       let item = event["item"] as? [String: Any] {
-                        let itemType = item["type"] as? String ?? ""
-                        var renderedText: String?
-                        switch itemType {
-                        case "agent_message", "message":
-                            if let text = item["text"] as? String, !text.isEmpty {
-                                renderedText = text
-                            } else if let contentArray = item["content"] as? [[String: Any]] {
-                                let joined = contentArray.compactMap { block -> String? in
-                                    guard let blockType = block["type"] as? String,
-                                          blockType == "output_text" || blockType == "text" else { return nil }
-                                    return block["text"] as? String
-                                }.joined()
-                                if !joined.isEmpty { renderedText = joined }
-                            }
-                        case "command_execution", "shell_command":
-                            let cmd: String? = {
-                                if let s = item["command"] as? String { return s }
-                                if let arr = item["command"] as? [String] { return arr.joined(separator: " ") }
-                                return nil
-                            }()
-                            if let cmd {
-                                var text = "$ \(cmd)"
-                                if let output = item["aggregated_output"] as? String,
-                                   !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                                    text += "\n" + output.trimmingCharacters(in: .whitespacesAndNewlines)
-                                }
-                                renderedText = text
-                            }
-                        case "file_change", "edit", "patch":
-                            if let changes = item["changes"] as? [[String: Any]] {
-                                let lines = changes.compactMap { change -> String? in
-                                    guard let path = change["path"] as? String else { return nil }
-                                    let kind = (change["kind"] as? String) ?? "edit"
-                                    let icon: String = kind == "add" ? "+" : (kind == "delete" ? "−" : "✎")
-                                    return "\(icon) \(path)"
-                                }
-                                if !lines.isEmpty { renderedText = lines.joined(separator: "\n") }
-                            } else if let path = item["path"] as? String {
-                                renderedText = "✎ \(path)"
-                            }
-                        case "reasoning":
-                            renderedText = nil
-                        default:
-                            if let text = item["text"] as? String, !text.isEmpty {
-                                renderedText = "[\(itemType)] \(text)"
-                            }
-                        }
-                        if let text = renderedText {
-                            if accumulatedResponseText.isEmpty {
-                                accumulatedResponseText = text
-                            } else {
-                                accumulatedResponseText += "\n\n" + text
-                            }
-                            let snapshot = accumulatedResponseText
-                            Task { @MainActor in await onProgressChunk(snapshot) }
-                        }
-                    }
-
-                    if eventType == "error" || eventType == "turn.failed" {
-                        let errorMessage: String = {
-                            if let msg = event["message"] as? String { return msg }
-                            if let errObj = event["error"] as? [String: Any],
-                               let msg = errObj["message"] as? String { return msg }
-                            return "Unknown Codex error"
-                        }()
-                        if !resumed {
-                            resumed = true
-                            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                            stderrPipe.fileHandleForReading.readabilityHandler = nil
-                            continuation.resume(throwing: CodexCLIError.agentError(errorMessage))
-                        }
-                    }
+                let update = streamState.appendStdoutChunk(chunk)
+                for snapshot in update.progressSnapshots {
+                    Task { @MainActor in onProgressChunk(snapshot) }
+                }
+                if let errorMessage = update.errorMessage {
+                    stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                    stderrPipe.fileHandleForReading.readabilityHandler = nil
+                    continuation.resume(throwing: CodexCLIError.agentError(errorMessage))
                 }
             }
 
             process.terminationHandler = { terminatedProcess in
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
                 stderrPipe.fileHandleForReading.readabilityHandler = nil
-                guard !resumed else { return }
-                resumed = true
-                if accumulatedResponseText.isEmpty {
-                    let stderrSnippet = stderrBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let exitCode = terminatedProcess.terminationStatus
-                    if !stderrSnippet.isEmpty {
-                        let detail = String(stderrSnippet.suffix(500))
-                        continuation.resume(throwing: CodexCLIError.agentError("codex exit \(exitCode): \(detail)"))
-                    } else {
-                        continuation.resume(throwing: CodexCLIError.noResponseReceived)
-                    }
-                } else {
+                guard let result = streamState.finishIfNeeded(exitCode: terminatedProcess.terminationStatus) else {
+                    return
+                }
+                switch result {
+                case .success(let accumulatedResponseText):
                     continuation.resume(returning: accumulatedResponseText)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
                 }
             }
         }

--- a/leanring-buddy/LocalIntentExecutor.swift
+++ b/leanring-buddy/LocalIntentExecutor.swift
@@ -70,11 +70,9 @@ enum LocalIntentExecutor {
             return .succeeded(spokenAcknowledgement: "")
         }
 
-        // Disk lookup. `fullPath(forApplication:)` is technically deprecated
-        // but is the only by-name lookup that works without a bundle ID.
         for candidate in casingCandidates(for: requestedName) {
-            if let appPath = NSWorkspace.shared.fullPath(forApplication: candidate) {
-                return await launchAppAt(URL(fileURLWithPath: appPath), label: candidate)
+            if let appURL = installedApplicationURL(named: candidate) {
+                return await launchAppAt(appURL, label: candidate)
             }
         }
 
@@ -82,9 +80,9 @@ enum LocalIntentExecutor {
         // ("feeform" instead of "Freeform"). Search the installed-app cache
         // for the closest match within a tight Levenshtein distance.
         if let fuzzyMatch = closestInstalledAppName(to: requestedName),
-           let appPath = NSWorkspace.shared.fullPath(forApplication: fuzzyMatch) {
+           let appURL = installedApplicationURL(named: fuzzyMatch) {
             FileLogger.log("🔍 LocalIntent: fuzzy-matched \"\(requestedName)\" → \"\(fuzzyMatch)\"")
-            return await launchAppAt(URL(fileURLWithPath: appPath), label: fuzzyMatch)
+            return await launchAppAt(appURL, label: fuzzyMatch)
         }
 
         return .failed(reason: "no app named \(requestedName) found")
@@ -142,18 +140,17 @@ enum LocalIntentExecutor {
     /// per process and caches the list. Used for fuzzy name matching when
     /// the user's spoken app name doesn't exactly match what's installed.
     private static let installedAppNamesCache: [String] = {
-        let appDirectories = [
-            "/Applications",
-            "/System/Applications",
-            "/System/Applications/Utilities",
-            NSHomeDirectory() + "/Applications",
-        ]
+        let appDirectories = installedApplicationDirectories
         let fileManager = FileManager.default
         var collectedAppNames: Set<String> = []
-        for directory in appDirectories {
-            guard let entries = try? fileManager.contentsOfDirectory(atPath: directory) else { continue }
-            for entry in entries where entry.hasSuffix(".app") {
-                let appName = String(entry.dropLast(".app".count))
+        for directoryURL in appDirectories {
+            guard let entries = try? fileManager.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+            for entryURL in entries where entryURL.pathExtension == "app" {
+                let appName = entryURL.deletingPathExtension().lastPathComponent
                 if !appName.isEmpty {
                     collectedAppNames.insert(appName)
                 }
@@ -162,6 +159,34 @@ enum LocalIntentExecutor {
         return collectedAppNames.sorted()
     }()
 
+    private static let installedApplicationDirectories: [URL] = [
+        URL(fileURLWithPath: "/Applications"),
+        URL(fileURLWithPath: "/System/Applications"),
+        URL(fileURLWithPath: "/System/Applications/Utilities"),
+        URL(fileURLWithPath: NSHomeDirectory() + "/Applications"),
+    ]
+
+    private static func installedApplicationURL(named requestedName: String) -> URL? {
+        let normalizedRequestedName = requestedName.lowercased()
+        let fileManager = FileManager.default
+
+        for directoryURL in installedApplicationDirectories {
+            guard let entries = try? fileManager.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+
+            for entryURL in entries where entryURL.pathExtension == "app" {
+                let appName = entryURL.deletingPathExtension().lastPathComponent
+                if appName.lowercased() == normalizedRequestedName {
+                    return entryURL
+                }
+            }
+        }
+
+        return nil
+    }
     /// Finds the installed app whose name is closest to `requestedName`,
     /// returning nil if no app is within the acceptable similarity bound.
     /// Tunable: ~30% character distance is generous enough for ASR typos

--- a/leanring-buddy/OpenAIAudioTranscriptionProvider.swift
+++ b/leanring-buddy/OpenAIAudioTranscriptionProvider.swift
@@ -56,7 +56,7 @@ final class OpenAIAudioTranscriptionProvider: BuddyTranscriptionProvider {
     }
 }
 
-private final class OpenAIAudioTranscriptionSession: BuddyStreamingTranscriptionSession {
+private final class OpenAIAudioTranscriptionSession: BuddyStreamingTranscriptionSession, @unchecked Sendable {
     let finalTranscriptFallbackDelaySeconds: TimeInterval = 8.0
 
     private struct TranscriptionResponse: Decodable {

--- a/leanring-buddy/OverlayWindow.swift
+++ b/leanring-buddy/OverlayWindow.swift
@@ -368,7 +368,7 @@ struct BlueCursorView: View {
             navigationAnimationTimer?.invalidate()
             companionManager.tearDownOnboardingVideo()
         }
-        .onChange(of: companionManager.detectedElementScreenLocation) { newLocation in
+        .onChange(of: companionManager.detectedElementScreenLocation) { _, newLocation in
             // When a UI element location is detected, navigate the buddy to
             // that position so it points at the element.
             guard let screenLocation = newLocation,


### PR DESCRIPTION
## What changed
- Removed the Info.plist resource-copy warning by excluding it from the target's synchronized resource membership.
- Updated SwiftUI onChange closures to the macOS 14-compatible two-argument form.
- Wrapped CLI stream parsing buffers and TLS warmup state in locked Sendable helpers so Swift concurrency checks stop flagging captured mutable state.
- Marked the transcription session objects as explicitly @unchecked Sendable where their internal state is already serialized.
- Replaced deprecated app path lookup with explicit application directory scanning.

## Why
Xcode was showing a large warning count during normal app runs. These warnings were mostly build phase noise, deprecated SwiftUI APIs, and Swift 6 concurrency diagnostics in the subprocess stream handlers.

## Validation
- git diff --check
- plutil -lint leanring-buddy.xcodeproj/project.pbxproj
- xcrun swiftc -typecheck -strict-concurrency=complete -warn-concurrency leanring-buddy/AnthropicChatClient.swift leanring-buddy/ClaudeCodeOAuthProvider.swift leanring-buddy/ClaudeAPI.swift leanring-buddy/ClaudeCodeCLIClient.swift leanring-buddy/CodexCLIClient.swift
- xcrun swiftc -typecheck -strict-concurrency=complete -warn-concurrency leanring-buddy/AppBundleConfiguration.swift leanring-buddy/DirectAPICredentials.swift leanring-buddy/BuddyAudioConversionSupport.swift leanring-buddy/OpenAIAudioTranscriptionProvider.swift leanring-buddy/AppleSpeechTranscriptionProvider.swift leanring-buddy/BuddyTranscriptionProvider.swift leanring-buddy/AssemblyAIStreamingTranscriptionProvider.swift
- xcrun swiftc -parse -strict-concurrency=complete -warn-concurrency leanring-buddy/AgentSessionDetailWindow.swift leanring-buddy/AgentSiblingsOverlayWindow.swift leanring-buddy/OverlayWindow.swift leanring-buddy/LocalIntentExecutor.swift

I avoided local xcodebuild because this repo warns that local Xcode builds can invalidate TCC permissions; GitHub CI should be the full build gate.