### PR TITLE
[codex] Speed up voice response routing

### DIFF
--- a/leanring-buddy/ClaudeCodeCLIClient.swift
+++ b/leanring-buddy/ClaudeCodeCLIClient.swift
@@ -200,6 +200,12 @@ final class ClaudeCodeCLIClient: AnthropicChatClient {
         return try await withCheckedThrowingContinuation { continuation in
             let streamState = ClaudeCodeCLIStreamState()
 
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+                print("🟥 claude stderr: \(chunk.trimmingCharacters(in: .whitespacesAndNewlines))")
+            }
+
             stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
                 guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
@@ -212,6 +218,7 @@ final class ClaudeCodeCLIClient: AnthropicChatClient {
 
             process.terminationHandler = { terminatedProcess in
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
                 guard let accumulatedResponseText = streamState.finishIfNeeded() else { return }
 
                 let duration = Date().timeIntervalSince(startTime)

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -72,18 +72,22 @@ final class CompanionManager: ObservableObject {
     // streamingResponseText, so no separate response overlay manager is needed.
 
     private lazy var claudeAPI: any AnthropicChatClient = {
-        // Use the claude CLI subprocess so no separate Anthropic API key is needed.
-        if ClaudeCodeCLIClient.isAvailable() {
-            FileLogger.log("✅ Using Claude Code CLI subprocess for responses")
-            return ClaudeCodeCLIClient(model: selectedModel)
-        }
-
         if let proxyURL = Self.configuredClaudeProxyURL() {
-            FileLogger.log("⚠️ Claude Code CLI not found — using configured Worker proxy")
+            FileLogger.log("✅ Using Claude API Worker proxy for responses")
             return ClaudeAPI(authMode: .proxyURL(proxyURL), model: selectedModel)
         }
 
-        FileLogger.log("⚠️ Claude Code CLI not found and no Worker proxy configured — using Claude Code OAuth direct API")
+        if ClaudeCodeOAuthProvider.isAvailable() {
+            FileLogger.log("✅ Using Claude Code OAuth direct API for responses")
+            return ClaudeAPI(authMode: .claudeCodeOAuth, model: selectedModel)
+        }
+
+        if ClaudeCodeCLIClient.isAvailable() {
+            FileLogger.log("⚠️ Claude API credentials unavailable — using Claude Code CLI subprocess fallback")
+            return ClaudeCodeCLIClient(model: selectedModel)
+        }
+
+        FileLogger.log("⚠️ No Claude API proxy, OAuth token, or CLI found — using Claude Code OAuth direct API and surfacing auth errors")
         return ClaudeAPI(authMode: .claudeCodeOAuth, model: selectedModel)
     }()
 
@@ -647,6 +651,13 @@ final class CompanionManager: ObservableObject {
         memoryCacheSystemPromptBlock + Self.companionVoiceResponseSystemPrompt
     }
 
+    private var textOnlyVoiceResponseSystemPromptWithMemory: String {
+        memoryCacheSystemPromptBlock + Self.companionVoiceResponseSystemPrompt + """
+
+        this turn does not include a screenshot. answer from the user's words, memory, and conversation context only. do not claim you can see the screen. end with [POINT:none].
+        """
+    }
+
     private static let companionVoiceResponseSystemPrompt = """
     you're clicky, a friendly always-on companion that lives in the user's menu bar. the user just spoke to you via push-to-talk and you can see their screen(s). your reply will be spoken aloud via text-to-speech, so write the way you'd actually talk. this is an ongoing conversation — you remember everything they've said before.
 
@@ -687,6 +698,58 @@ final class CompanionManager: ObservableObject {
     - user asks how to commit in xcode: "see that source control menu up top? click that and hit commit, or you can use command option c as a shortcut. [POINT:285,11:source control]"
     - element is on screen 2 (not where cursor is): "that's over on your other monitor — see the terminal window? [POINT:400,300:terminal:screen2]"
     """
+
+    nonisolated static func shouldCaptureScreenForTranscript(_ transcript: String) -> Bool {
+        let lower = transcript
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !lower.isEmpty else { return false }
+
+        let visualPhrases = [
+            "on my screen", "on the screen", "on screen",
+            "what do you see", "what can you see", "what's on",
+            "what is on", "look at", "look over", "take a look",
+            "do you see", "can you see", "this screen",
+            "this page", "this window", "this app", "this error",
+            "this code", "this file", "this button", "this menu",
+            "that button", "that menu", "that window",
+            "point at", "point to", "show me where",
+            "where is", "where's", "which button", "which menu",
+        ]
+        if visualPhrases.contains(where: { lower.contains($0) }) {
+            return true
+        }
+
+        let words = Set(
+            lower
+                .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+                .map(String.init)
+        )
+        let visualWords: Set<String> = [
+            "screen", "screenshot", "visible", "shown", "looking",
+            "cursor", "pointer", "button", "menu", "icon", "tab",
+            "window", "panel", "sidebar", "toolbar", "dialog",
+            "xcode", "chrome", "safari", "browser", "page",
+            "click", "tap", "select", "navigate", "scroll",
+        ]
+        if !words.isDisjoint(with: visualWords) {
+            return true
+        }
+
+        let textOnlyPrefixes = [
+            "what is", "what's", "who is", "who's", "why",
+            "how do i", "how can i", "how should i",
+            "explain", "define", "tell me about", "teach me",
+            "brainstorm", "write", "draft", "rewrite", "summarize",
+            "should i", "help me think", "give me ideas",
+        ]
+        if textOnlyPrefixes.contains(where: { lower.hasPrefix($0) }) {
+            return false
+        }
+
+        let deicticWords: Set<String> = ["this", "that", "these", "those", "here"]
+        return !words.isDisjoint(with: deicticWords)
+    }
 
     private func routeTranscriptToCodexIfNeeded(_ transcript: String) async -> Bool {
         // Route to Codex before screenshot capture. Agent tasks do not need
@@ -826,18 +889,29 @@ final class CompanionManager: ObservableObject {
                     return
                 }
 
-                // Capture all connected screens so the AI has full context
-                let screenCaptures = try await CompanionScreenCaptureUtility.captureAllScreensAsJPEG()
-                logPipelinePhase("screenshots captured (\(screenCaptures.count))")
+                let shouldCaptureScreen = Self.shouldCaptureScreenForTranscript(transcript)
+                let screenCaptures: [CompanionScreenCapture]
+                let labeledImages: [(data: Data, label: String)]
+                if shouldCaptureScreen {
+                    // Capture all connected screens only when the transcript
+                    // actually needs visual context. Vision turns are much
+                    // slower and send a lot more data to Claude.
+                    screenCaptures = try await CompanionScreenCaptureUtility.captureAllScreensAsJPEG()
+                    logPipelinePhase("screenshots captured (\(screenCaptures.count))")
 
-                guard !Task.isCancelled else { return }
+                    guard !Task.isCancelled else { return }
 
-                // Build image labels with the actual screenshot pixel dimensions
-                // so Claude's coordinate space matches the image it sees. We
-                // scale from screenshot pixels to display points ourselves.
-                let labeledImages = screenCaptures.map { capture in
-                    let dimensionInfo = " (image dimensions: \(capture.screenshotWidthInPixels)x\(capture.screenshotHeightInPixels) pixels)"
-                    return (data: capture.imageData, label: capture.label + dimensionInfo)
+                    // Build image labels with the actual screenshot pixel dimensions
+                    // so Claude's coordinate space matches the image it sees. We
+                    // scale from screenshot pixels to display points ourselves.
+                    labeledImages = screenCaptures.map { capture in
+                        let dimensionInfo = " (image dimensions: \(capture.screenshotWidthInPixels)x\(capture.screenshotHeightInPixels) pixels)"
+                        return (data: capture.imageData, label: capture.label + dimensionInfo)
+                    }
+                } else {
+                    screenCaptures = []
+                    labeledImages = []
+                    logPipelinePhase("text-only turn (no screenshot)")
                 }
 
                 // Pass conversation history so Claude remembers prior exchanges
@@ -858,7 +932,9 @@ final class CompanionManager: ObservableObject {
                 var didReceiveFirstChunk = false
                 let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
                     images: labeledImages,
-                    systemPrompt: companionVoiceResponseSystemPromptWithMemory,
+                    systemPrompt: shouldCaptureScreen
+                        ? companionVoiceResponseSystemPromptWithMemory
+                        : textOnlyVoiceResponseSystemPromptWithMemory,
                     conversationHistory: historyForAPI,
                     userPrompt: userPromptWithAppContext,
                     onTextChunk: { [weak self] _ in

--- a/leanring-buddy/LocalIntentExecutor.swift
+++ b/leanring-buddy/LocalIntentExecutor.swift
@@ -32,6 +32,8 @@ enum LocalIntentExecutor {
             return await launchOrActivateApp(named: name)
         case .quitApp(let name):
             return quitApp(named: name)
+        case .createNote(let text):
+            return await createNote(text: text)
         case .clickByName(let name):
             // Brief settle pause so click lands AFTER any preceding launch
             // has actually focused its window. Cheap insurance for chains.
@@ -52,6 +54,22 @@ enum LocalIntentExecutor {
         case .unmatched:
             return .failed(reason: "no local intent matched")
         }
+    }
+
+    private static func createNote(text: String) async -> ExecutionResult {
+        let launchResult = await launchOrActivateApp(named: "Notes")
+        guard case .succeeded = launchResult else { return launchResult }
+
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        let newNoteResult = pressKeyChord("cmd+n")
+        guard case .succeeded = newNoteResult else { return newNoteResult }
+
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        let typeResult = typeText(text)
+        if case .succeeded = typeResult {
+            FileLogger.log("⚡️ LocalIntent: create note \"\(text.prefix(80))\(text.count > 80 ? "…" : "")\"")
+        }
+        return typeResult
     }
 
     // MARK: - App launch / activate

--- a/leanring-buddy/LocalIntentRouter.swift
+++ b/leanring-buddy/LocalIntentRouter.swift
@@ -28,6 +28,8 @@ enum LocalIntent: Equatable {
     case launchOrActivateApp(name: String)
     /// Send a graceful Quit to the named app.
     case quitApp(name: String)
+    /// Create a new Apple Notes note with the given text.
+    case createNote(text: String)
     /// Click any element in the frontmost app's accessibility tree whose
     /// title matches `targetName`. Generic — covers menu bar items, buttons,
     /// menu items, links, checkboxes, anything labeled.
@@ -70,6 +72,10 @@ enum LocalIntentRouter {
 
         if isCurrentTimeQuery(normalized) {
             return .currentTime
+        }
+
+        if let noteText = parseCreateNoteCommand(normalized) {
+            return .createNote(text: preserveOriginalCasing(of: noteText, from: transcript))
         }
 
         // "navigate to <X>" / "go to the <X> icon" / "show me the <X> menu"
@@ -344,6 +350,32 @@ enum LocalIntentRouter {
         // does that itself, but doing it here makes the matched name cleaner.
         let withoutNoun = stripTrailingUINoun(stripped)
         return withoutNoun.isEmpty ? nil : withoutNoun
+    }
+
+    /// Recognizes common note-taking requests so they do not have to wait
+    /// for Claude to emit OPEN_APP/KEY/TYPE tags.
+    private static func parseCreateNoteCommand(_ text: String) -> String? {
+        let patterns = [
+            #"(?:^|\b)(?:make|create|write|take|add)\s+(?:a\s+)?note(?:\s+for\s+me)?(?:\s+(?:to|that\s+says|saying|about|of))?\s+(.+)$"#,
+            #"(?:^|\b)(?:notes?|notes\s+app)\s+(?:and\s+)?(?:make|create|write|take|add)\s+(?:a\s+)?note(?:\s+for\s+me)?(?:\s+(?:to|that\s+says|saying|about|of))?\s+(.+)$"#,
+        ]
+
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { continue }
+            let range = NSRange(text.startIndex..<text.endIndex, in: text)
+            guard let match = regex.firstMatch(in: text, range: range),
+                  match.numberOfRanges >= 2,
+                  let noteRange = Range(match.range(at: 1), in: text)
+            else { continue }
+
+            let rawNoteText = String(text[noteRange])
+            let cleanedNoteText = stripTrailingFillerAndPunctuation(rawNoteText)
+                .trimmingCharacters(in: CharacterSet(charactersIn: " -—:,.!?"))
+            guard !cleanedNoteText.isEmpty else { continue }
+            return cleanedNoteText
+        }
+
+        return nil
     }
 
     /// Strips noisy trailing phrases voice users often append: " on my mac",

--- a/leanring-buddyTests/leanring_buddyTests.swift
+++ b/leanring-buddyTests/leanring_buddyTests.swift
@@ -83,10 +83,26 @@ struct leanring_buddyTests {
         #expect(intent == .launchOrActivateApp(name: "freeform"))
     }
 
+    @Test func localIntentCreatesNotesWithoutClaudeRoundTrip() async throws {
+        let intent = LocalIntentRouter.route(transcript: "Um, go on my Notes app and make a note for me to make pasta tonight.")
+
+        #expect(intent == .createNote(text: "make pasta tonight"))
+    }
+
     @Test func localIntentRoutesBareContinuationToClickTarget() async throws {
         let intent = LocalIntentRouter.route(transcript: "to the Apple icon.")
 
         #expect(intent == .clickByName(targetName: "apple"))
+    }
+
+    @Test func generalQuestionsSkipScreenshotCapture() async throws {
+        #expect(!CompanionManager.shouldCaptureScreenForTranscript("What is HTML?"))
+        #expect(!CompanionManager.shouldCaptureScreenForTranscript("Brainstorm pricing ideas for ipop."))
+    }
+
+    @Test func screenQuestionsKeepScreenshotCapture() async throws {
+        #expect(CompanionManager.shouldCaptureScreenForTranscript("What is on my screen?"))
+        #expect(CompanionManager.shouldCaptureScreenForTranscript("How do I fix this error in Xcode?"))
     }
 
     @Test func actionOnlyResponseHasNoSpokenWhitespace() async throws {


### PR DESCRIPTION
## What changed
- Prefer the Worker proxy or Claude Code OAuth direct API for normal voice responses; use the claude CLI only as a fallback.
- Skip screenshot capture for text-only/general questions and add a no-screenshot prompt variant.
- Route common Apple Notes creation requests locally so they do not wait for Claude action tags.
- Drain stderr from the claude CLI fallback so it cannot block on pipe output.
- Added regression coverage for note routing and screenshot/no-screenshot classification.

## Why
Recent logs showed normal turns waiting 10-20 seconds, and one misrouted multi-session request waited more than seven minutes in the slow screenshot/Claude path. The app should answer text questions and simple Mac actions without paying the full vision/subprocess cost.

## Validation
- git diff --check
- swiftc strict-concurrency typecheck for Anthropic/Codex/Claude CLI clients
- swiftc strict-concurrency typecheck for FileLogger, LocalIntentRouter, LocalIntentExecutor
- swiftc parse for CompanionManager and test source

Note: I did not intentionally run terminal xcodebuild because this repo warns it can invalidate TCC permissions.