### PR TITLE
Add optional Z.ai response provider

### DIFF
--- a/docs/zai-provider.md
+++ b/docs/zai-provider.md
@@ -1,0 +1,48 @@
+# Z.ai Provider
+
+ipop can use Z.ai for normal voice responses and screenshot-aware turns without going through the Claude CLI.
+
+## Enable Locally
+
+```sh
+defaults write com.yourcompany.leanring-buddy ClickyAIProvider zai
+defaults write com.yourcompany.leanring-buddy ClickyZAIAPIKey '<your-zai-api-key>'
+```
+
+Optional model overrides:
+
+```sh
+defaults write com.yourcompany.leanring-buddy ClickyZAITextModel glm-4.5
+defaults write com.yourcompany.leanring-buddy ClickyZAIVisionModel glm-4.5v
+```
+
+To disable and return to the Claude provider chain:
+
+```sh
+defaults delete com.yourcompany.leanring-buddy ClickyAIProvider
+```
+
+## Environment Overrides
+
+For command-line launches or CI smoke tests:
+
+```sh
+CLICKY_AI_PROVIDER=zai \
+CLICKY_ZAI_API_KEY='<your-zai-api-key>' \
+open /path/to/Clicky.app
+```
+
+Supported env vars:
+
+- `CLICKY_AI_PROVIDER`
+- `CLICKY_ZAI_API_KEY`
+- `CLICKY_ZAI_ENDPOINT_URL`
+- `CLICKY_ZAI_TEXT_MODEL`
+- `CLICKY_ZAI_VISION_MODEL`
+
+## Notes
+
+- Text turns default to `glm-4.5`.
+- Screenshot turns default to `glm-4.5v`.
+- Existing Claude proxy/OAuth/CLI behavior remains the fallback when Z.ai is not explicitly enabled.
+- Codex agent sessions are separate; this provider does not replace Codex app-server authentication.

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -72,6 +72,11 @@ final class CompanionManager: ObservableObject {
     // streamingResponseText, so no separate response overlay manager is needed.
 
     private lazy var claudeAPI: any AnthropicChatClient = {
+        if let zaiClient = ZAIChatClient.configuredIfEnabled(selectedModel: selectedModel) {
+            FileLogger.log("✅ Using Z.ai direct API for responses")
+            return zaiClient
+        }
+
         if let proxyURL = Self.configuredClaudeProxyURL() {
             FileLogger.log("✅ Using Claude API Worker proxy for responses")
             return ClaudeAPI(authMode: .proxyURL(proxyURL), model: selectedModel)

--- a/leanring-buddy/ZAIChatClient.swift
+++ b/leanring-buddy/ZAIChatClient.swift
@@ -1,0 +1,288 @@
+//
+//  ZAIChatClient.swift
+//  leanring-buddy
+//
+//  Optional direct Z.ai provider for fast text and screenshot turns.
+//  Enabled only when runtime config selects provider "zai".
+//
+
+import Foundation
+
+enum ZAIChatClientError: Error, LocalizedError {
+    case notConfigured
+    case invalidResponse
+    case emptyResponse
+    case apiError(statusCode: Int, body: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Z.ai is not configured. Set ClickyAIProvider=zai and ClickyZAIAPIKey."
+        case .invalidResponse:
+            return "Z.ai returned an invalid response."
+        case .emptyResponse:
+            return "Z.ai returned an empty response."
+        case .apiError(let statusCode, let body):
+            return "Z.ai API error (\(statusCode)): \(body)"
+        }
+    }
+}
+
+final class ZAIChatClient: AnthropicChatClient {
+    private static let defaultEndpoint = "https://api.z.ai/api/coding/paas/v4/chat/completions"
+    private static let defaultTextModel = "glm-4.5"
+    private static let defaultVisionModel = "glm-4.5v"
+
+    private let apiKey: String
+    private let endpointURL: URL
+    private let textModel: String
+    private let visionModel: String
+    var model: String
+    private let session: URLSession
+
+    init(
+        apiKey: String,
+        endpointURL: URL = URL(string: ZAIChatClient.defaultEndpoint)!,
+        selectedModel: String,
+        textModel: String = ZAIChatClient.defaultTextModel,
+        visionModel: String = ZAIChatClient.defaultVisionModel,
+        session: URLSession = .shared
+    ) {
+        self.apiKey = apiKey
+        self.endpointURL = endpointURL
+        self.model = selectedModel
+        self.textModel = textModel
+        self.visionModel = visionModel
+        self.session = session
+    }
+
+    static func configuredIfEnabled(selectedModel: String) -> ZAIChatClient? {
+        guard let provider = runtimeString(
+            defaultsKeys: ["ClickyAIProvider", "AIProvider"],
+            infoKeys: ["ClickyAIProvider", "AIProvider"],
+            environmentKeys: ["CLICKY_AI_PROVIDER", "AI_PROVIDER"]
+        )?.lowercased(),
+              provider == "zai" || provider == "z.ai" else {
+            return nil
+        }
+
+        guard let apiKey = runtimeString(
+            defaultsKeys: ["ClickyZAIAPIKey", "ZAIAPIKey"],
+            infoKeys: ["ClickyZAIAPIKey", "ZAIAPIKey"],
+            environmentKeys: ["CLICKY_ZAI_API_KEY", "ZAI_API_KEY"]
+        ) else {
+            return nil
+        }
+
+        let endpointString = runtimeString(
+            defaultsKeys: ["ClickyZAIEndpointURL", "ZAIEndpointURL"],
+            infoKeys: ["ClickyZAIEndpointURL", "ZAIEndpointURL"],
+            environmentKeys: ["CLICKY_ZAI_ENDPOINT_URL", "ZAI_ENDPOINT_URL"]
+        ) ?? defaultEndpoint
+
+        guard let endpointURL = URL(string: endpointString) else { return nil }
+
+        let textModel = runtimeString(
+            defaultsKeys: ["ClickyZAITextModel", "ZAITextModel"],
+            infoKeys: ["ClickyZAITextModel", "ZAITextModel"],
+            environmentKeys: ["CLICKY_ZAI_TEXT_MODEL", "ZAI_TEXT_MODEL"]
+        ) ?? defaultTextModel
+
+        let visionModel = runtimeString(
+            defaultsKeys: ["ClickyZAIVisionModel", "ZAIVisionModel"],
+            infoKeys: ["ClickyZAIVisionModel", "ZAIVisionModel"],
+            environmentKeys: ["CLICKY_ZAI_VISION_MODEL", "ZAI_VISION_MODEL"]
+        ) ?? defaultVisionModel
+
+        return ZAIChatClient(
+            apiKey: apiKey,
+            endpointURL: endpointURL,
+            selectedModel: selectedModel,
+            textModel: textModel,
+            visionModel: visionModel
+        )
+    }
+
+    nonisolated static func resolvedModel(
+        selectedModel: String,
+        hasImages: Bool,
+        textModel: String = defaultTextModel,
+        visionModel: String = defaultVisionModel
+    ) -> String {
+        if selectedModel.lowercased().hasPrefix("glm-") {
+            return selectedModel
+        }
+        return hasImages ? visionModel : textModel
+    }
+
+    func analyzeImageStreaming(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String,
+        onTextChunk: @escaping @MainActor @Sendable (String) -> Void
+    ) async throws -> (text: String, duration: TimeInterval) {
+        let startTime = Date()
+        let request = try makeRequest(
+            images: images,
+            systemPrompt: systemPrompt,
+            conversationHistory: conversationHistory,
+            userPrompt: userPrompt
+        )
+
+        let payloadMB = Double(request.httpBody?.count ?? 0) / 1_048_576.0
+        print("🌐 Z.ai streaming request: \(String(format: "%.1f", payloadMB))MB, \(images.count) image(s)")
+
+        let (byteStream, response) = try await session.bytes(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ZAIChatClientError.invalidResponse
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            var errorLines: [String] = []
+            for try await line in byteStream.lines {
+                errorLines.append(line)
+            }
+            throw ZAIChatClientError.apiError(
+                statusCode: httpResponse.statusCode,
+                body: errorLines.joined(separator: "\n")
+            )
+        }
+
+        var accumulatedResponseText = ""
+        for try await line in byteStream.lines {
+            guard line.hasPrefix("data:") else { continue }
+            let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+            if payload == "[DONE]" { break }
+
+            guard let data = payload.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let choices = json["choices"] as? [[String: Any]],
+                  let firstChoice = choices.first,
+                  let delta = firstChoice["delta"] as? [String: Any] else {
+                continue
+            }
+
+            if let textChunk = delta["content"] as? String, !textChunk.isEmpty {
+                accumulatedResponseText += textChunk
+                await onTextChunk(accumulatedResponseText)
+            }
+        }
+
+        guard !accumulatedResponseText.isEmpty else {
+            throw ZAIChatClientError.emptyResponse
+        }
+
+        return (text: accumulatedResponseText, duration: Date().timeIntervalSince(startTime))
+    }
+
+    private func makeRequest(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String
+    ) throws -> URLRequest {
+        var request = URLRequest(url: endpointURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 120
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("en-US,en", forHTTPHeaderField: "Accept-Language")
+
+        var messages: [[String: Any]] = [
+            ["role": "system", "content": adaptedSystemPrompt(systemPrompt)]
+        ]
+
+        for (userPlaceholder, assistantResponse) in conversationHistory {
+            messages.append(["role": "user", "content": userPlaceholder])
+            messages.append(["role": "assistant", "content": assistantResponse])
+        }
+
+        if images.isEmpty {
+            messages.append(["role": "user", "content": userPrompt])
+        } else {
+            var contentBlocks: [[String: Any]] = []
+            for image in images {
+                let mediaType = detectImageMediaType(for: image.data)
+                let dataURL = "data:\(mediaType);base64,\(image.data.base64EncodedString())"
+                contentBlocks.append([
+                    "type": "image_url",
+                    "image_url": ["url": dataURL]
+                ])
+                contentBlocks.append([
+                    "type": "text",
+                    "text": image.label
+                ])
+            }
+            contentBlocks.append(["type": "text", "text": userPrompt])
+            messages.append(["role": "user", "content": contentBlocks])
+        }
+
+        let body: [String: Any] = [
+            "model": Self.resolvedModel(
+                selectedModel: model,
+                hasImages: !images.isEmpty,
+                textModel: textModel,
+                visionModel: visionModel
+            ),
+            "messages": messages,
+            "max_tokens": 1024,
+            "temperature": 0.1,
+            "stream": true,
+            "thinking": ["type": "disabled"]
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private func adaptedSystemPrompt(_ systemPrompt: String) -> String {
+        systemPrompt + """
+
+        z.ai provider compatibility:
+        - if you use mac action tags, output only this exact bracket grammar: [OPEN_APP:Name] [QUIT_APP:Name] [CLICK:Target] [TYPE:literal text] [KEY:cmd+n] [SCROLL:down].
+        - do not output xml, json, markdown fences, LAUNCH(...), CLICK(box=...), or tool-call shaped text for mac actions.
+        - never emit no-op tags like [CLICK:none]. omit the action instead.
+        - for creating a note, prefer [OPEN_APP:Notes] [KEY:cmd+n] [TYPE:literal note text].
+        - if the user asks for a notes/action task and the tags fully complete it, output only the tags.
+        """
+    }
+
+    private func detectImageMediaType(for imageData: Data) -> String {
+        let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+        if [UInt8](imageData.prefix(4)) == pngSignature {
+            return "image/png"
+        }
+        return "image/jpeg"
+    }
+
+    private static func runtimeString(
+        defaultsKeys: [String],
+        infoKeys: [String],
+        environmentKeys: [String]
+    ) -> String? {
+        for key in environmentKeys {
+            if let value = ProcessInfo.processInfo.environment[key]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !value.isEmpty {
+                return value
+            }
+        }
+
+        for key in defaultsKeys {
+            if let value = UserDefaults.standard.string(forKey: key)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !value.isEmpty {
+                return value
+            }
+        }
+
+        for key in infoKeys {
+            if let value = AppBundleConfiguration.stringValue(forKey: key) {
+                return value
+            }
+        }
+
+        return nil
+    }
+}

--- a/leanring-buddyTests/leanring_buddyTests.swift
+++ b/leanring-buddyTests/leanring_buddyTests.swift
@@ -71,6 +71,27 @@ struct leanring_buddyTests {
         #expect(tasks[1] == "find the latest spicy companies that have been funded with a similar concept")
     }
 
+    @Test func zaiProviderMapsClaudeModelSelectionToZAIModels() async throws {
+        #expect(
+            ZAIChatClient.resolvedModel(
+                selectedModel: "claude-haiku-4-5-20251001",
+                hasImages: false
+            ) == "glm-4.5"
+        )
+        #expect(
+            ZAIChatClient.resolvedModel(
+                selectedModel: "claude-haiku-4-5-20251001",
+                hasImages: true
+            ) == "glm-4.5v"
+        )
+        #expect(
+            ZAIChatClient.resolvedModel(
+                selectedModel: "glm-4.6v",
+                hasImages: true
+            ) == "glm-4.6v"
+        )
+    }
+
     @Test func localIntentCleansCutOffAppLaunchSpeech() async throws {
         let intent = LocalIntentRouter.route(transcript: "Can you open up Google for me and—")
 


### PR DESCRIPTION
## Summary
- Add a feature-flagged ZAIChatClient using Z.ai's coding/OpenAI-compatible chat completions endpoint
- Route normal app responses through Z.ai only when ClickyAIProvider=zai and a Z.ai key is configured
- Keep Claude proxy/OAuth/CLI as the fallback path when Z.ai is not enabled
- Map existing Claude model selections to default Z.ai text/vision models and document local setup

## Verification
- git diff --check
- xcrun swiftc -parse leanring-buddy/AnthropicChatClient.swift leanring-buddy/AppBundleConfiguration.swift leanring-buddy/ZAIChatClient.swift leanring-buddy/CompanionManager.swift
- Swift smoke test against Z.ai returned [OPEN_APP:Notes] [KEY:cmd+n] [TYPE:make pasta tonight] in 1.57s