### PR TITLE
Add provider retry resilience

### DIFF
--- a/docs/orchestration-resilience.md
+++ b/docs/orchestration-resilience.md
@@ -1,0 +1,27 @@
+# Orchestration Resilience
+
+The response pipeline now retries only the provider call inside a voice turn.
+By the time the retry wrapper runs, ipop has already captured the transcript,
+optional screenshots, memory context, and routing decision. A retry therefore
+does not restart dictation, recapture the screen, re-run local intent routing,
+or duplicate the entire workflow.
+
+## Retried Failures
+
+- HTTP `429` rate limits, honoring `Retry-After` when providers send it.
+- Temporary HTTP failures: `408`, `409`, `425`, `500`, `502`, `503`, `504`.
+- URL/network timeouts and transient connection interruptions.
+- Provider response parse failures such as invalid response envelopes or empty
+  streamed output.
+
+## Not Retried
+
+- User cancellation.
+- Authentication/configuration problems such as `401` or `403`.
+- Non-transient provider errors.
+
+## Attempts
+
+The default policy makes up to three provider attempts with short exponential
+backoff. The provider wrapper is shared by Z.ai, Claude API, Claude proxy, and
+Claude CLI fallback paths.

--- a/leanring-buddy/ClaudeAPI.swift
+++ b/leanring-buddy/ClaudeAPI.swift
@@ -193,11 +193,7 @@ class ClaudeAPI: AnthropicChatClient {
         let (byteStream, response) = try await session.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw NSError(
-                domain: "ClaudeAPI",
-                code: -1,
-                userInfo: [NSLocalizedDescriptionKey: "Invalid HTTP response"]
-            )
+            throw ProviderPipelineError.invalidResponse(provider: "Claude")
         }
 
         // If non-2xx status, read the full body as error text
@@ -207,10 +203,11 @@ class ClaudeAPI: AnthropicChatClient {
                 errorBodyChunks.append(line)
             }
             let errorBody = errorBodyChunks.joined(separator: "\n")
-            throw NSError(
-                domain: "ClaudeAPI",
-                code: httpResponse.statusCode,
-                userInfo: [NSLocalizedDescriptionKey: "API Error (\(httpResponse.statusCode)): \(errorBody)"]
+            throw ProviderPipelineError.apiError(
+                provider: "Claude",
+                statusCode: httpResponse.statusCode,
+                retryAfterSeconds: Self.retryAfterSeconds(from: httpResponse),
+                body: errorBody
             )
         }
 
@@ -242,6 +239,10 @@ class ClaudeAPI: AnthropicChatClient {
                 let currentAccumulatedText = accumulatedResponseText
                 await onTextChunk(currentAccumulatedText)
             }
+        }
+
+        guard !accumulatedResponseText.isEmpty else {
+            throw ProviderPipelineError.emptyResponse(provider: "Claude")
         }
 
         let duration = Date().timeIntervalSince(startTime)
@@ -301,13 +302,17 @@ class ClaudeAPI: AnthropicChatClient {
 
         let (data, response) = try await session.data(for: request)
 
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200...299).contains(httpResponse.statusCode) else {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ProviderPipelineError.invalidResponse(provider: "Claude")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
             let responseString = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw NSError(
-                domain: "ClaudeAPI",
-                code: (response as? HTTPURLResponse)?.statusCode ?? -1,
-                userInfo: [NSLocalizedDescriptionKey: "API Error: \(responseString)"]
+            throw ProviderPipelineError.apiError(
+                provider: "Claude",
+                statusCode: httpResponse.statusCode,
+                retryAfterSeconds: Self.retryAfterSeconds(from: httpResponse),
+                body: responseString
             )
         }
 
@@ -315,14 +320,29 @@ class ClaudeAPI: AnthropicChatClient {
         guard let content = json?["content"] as? [[String: Any]],
               let textBlock = content.first(where: { ($0["type"] as? String) == "text" }),
               let text = textBlock["text"] as? String else {
-            throw NSError(
-                domain: "ClaudeAPI",
-                code: -1,
-                userInfo: [NSLocalizedDescriptionKey: "Invalid response format"]
-            )
+            throw ProviderPipelineError.invalidResponse(provider: "Claude")
         }
 
         let duration = Date().timeIntervalSince(startTime)
         return (text: text, duration: duration)
+    }
+
+    private static func retryAfterSeconds(from response: HTTPURLResponse) -> TimeInterval? {
+        guard let value = response.value(forHTTPHeaderField: "Retry-After")?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+
+        if let seconds = TimeInterval(value) {
+            return seconds
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss z"
+        guard let retryDate = formatter.date(from: value) else { return nil }
+        return max(0, retryDate.timeIntervalSinceNow)
     }
 }

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -74,26 +74,38 @@ final class CompanionManager: ObservableObject {
     private lazy var claudeAPI: any AnthropicChatClient = {
         if let zaiClient = ZAIChatClient.configuredIfEnabled(selectedModel: selectedModel) {
             FileLogger.log("✅ Using Z.ai direct API for responses")
-            return zaiClient
+            return RetryingChatClient(zaiClient, providerName: "Z.ai")
         }
 
         if let proxyURL = Self.configuredClaudeProxyURL() {
             FileLogger.log("✅ Using Claude API Worker proxy for responses")
-            return ClaudeAPI(authMode: .proxyURL(proxyURL), model: selectedModel)
+            return RetryingChatClient(
+                ClaudeAPI(authMode: .proxyURL(proxyURL), model: selectedModel),
+                providerName: "Claude proxy"
+            )
         }
 
         if ClaudeCodeOAuthProvider.isAvailable() {
             FileLogger.log("✅ Using Claude Code OAuth direct API for responses")
-            return ClaudeAPI(authMode: .claudeCodeOAuth, model: selectedModel)
+            return RetryingChatClient(
+                ClaudeAPI(authMode: .claudeCodeOAuth, model: selectedModel),
+                providerName: "Claude OAuth"
+            )
         }
 
         if ClaudeCodeCLIClient.isAvailable() {
             FileLogger.log("⚠️ Claude API credentials unavailable — using Claude Code CLI subprocess fallback")
-            return ClaudeCodeCLIClient(model: selectedModel)
+            return RetryingChatClient(
+                ClaudeCodeCLIClient(model: selectedModel),
+                providerName: "Claude CLI"
+            )
         }
 
         FileLogger.log("⚠️ No Claude API proxy, OAuth token, or CLI found — using Claude Code OAuth direct API and surfacing auth errors")
-        return ClaudeAPI(authMode: .claudeCodeOAuth, model: selectedModel)
+        return RetryingChatClient(
+            ClaudeAPI(authMode: .claudeCodeOAuth, model: selectedModel),
+            providerName: "Claude OAuth"
+        )
     }()
 
     private static func configuredClaudeProxyURL() -> String? {

--- a/leanring-buddy/ProviderPipelineError.swift
+++ b/leanring-buddy/ProviderPipelineError.swift
@@ -1,0 +1,36 @@
+//
+//  ProviderPipelineError.swift
+//  leanring-buddy
+//
+//  Normalized provider errors so the orchestration layer can distinguish
+//  retryable rate limits/timeouts/parse failures from hard failures.
+//
+
+import Foundation
+
+enum ProviderPipelineError: Error, LocalizedError {
+    case invalidResponse(provider: String)
+    case emptyResponse(provider: String)
+    case apiError(provider: String, statusCode: Int, retryAfterSeconds: TimeInterval?, body: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse(let provider):
+            return "\(provider) returned an invalid response."
+        case .emptyResponse(let provider):
+            return "\(provider) returned an empty response."
+        case .apiError(let provider, let statusCode, _, let body):
+            return "\(provider) API error (\(statusCode)): \(body)"
+        }
+    }
+
+    var statusCode: Int? {
+        guard case .apiError(_, let statusCode, _, _) = self else { return nil }
+        return statusCode
+    }
+
+    var retryAfterSeconds: TimeInterval? {
+        guard case .apiError(_, _, let retryAfterSeconds, _) = self else { return nil }
+        return retryAfterSeconds
+    }
+}

--- a/leanring-buddy/RetryingChatClient.swift
+++ b/leanring-buddy/RetryingChatClient.swift
@@ -1,0 +1,172 @@
+//
+//  RetryingChatClient.swift
+//  leanring-buddy
+//
+//  Retries only the provider call inside a turn. The transcript, screenshots,
+//  routing decision, and conversation context are already captured by the time
+//  this wrapper runs, so retries do not restart the whole workflow.
+//
+
+import Foundation
+
+struct ChatProviderRetryDecision: Equatable {
+    let reason: String
+    let delaySeconds: TimeInterval
+}
+
+enum ChatProviderRetryPolicy {
+    static let maxAttempts = 3
+
+    private static let retryableHTTPStatusCodes: Set<Int> = [
+        408, 409, 425, 429, 500, 502, 503, 504
+    ]
+
+    private static let retryableURLErrorCodes: Set<URLError.Code> = [
+        .timedOut,
+        .cannotFindHost,
+        .cannotConnectToHost,
+        .dnsLookupFailed,
+        .networkConnectionLost,
+        .notConnectedToInternet,
+        .secureConnectionFailed,
+        .cannotLoadFromNetwork
+    ]
+
+    nonisolated static func decision(for error: Error, attempt: Int) -> ChatProviderRetryDecision? {
+        guard attempt < maxAttempts else { return nil }
+
+        if error is CancellationError {
+            return nil
+        }
+
+        if let providerError = error as? ProviderPipelineError {
+            switch providerError {
+            case .emptyResponse:
+                return ChatProviderRetryDecision(
+                    reason: "empty provider response",
+                    delaySeconds: backoffDelay(for: attempt, retryAfterSeconds: nil)
+                )
+            case .invalidResponse:
+                return ChatProviderRetryDecision(
+                    reason: "provider response parse failure",
+                    delaySeconds: backoffDelay(for: attempt, retryAfterSeconds: nil)
+                )
+            case .apiError(_, let statusCode, let retryAfterSeconds, _):
+                guard retryableHTTPStatusCodes.contains(statusCode) else { return nil }
+                let reason = statusCode == 429 ? "rate limited" : "temporary HTTP \(statusCode)"
+                return ChatProviderRetryDecision(
+                    reason: reason,
+                    delaySeconds: backoffDelay(for: attempt, retryAfterSeconds: retryAfterSeconds)
+                )
+            }
+        }
+
+        if let urlError = error as? URLError,
+           retryableURLErrorCodes.contains(urlError.code) {
+            return ChatProviderRetryDecision(
+                reason: "network timeout/interruption",
+                delaySeconds: backoffDelay(for: attempt, retryAfterSeconds: nil)
+            )
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain,
+           retryableURLErrorCodes.contains(URLError.Code(rawValue: nsError.code)) {
+            return ChatProviderRetryDecision(
+                reason: "network timeout/interruption",
+                delaySeconds: backoffDelay(for: attempt, retryAfterSeconds: nil)
+            )
+        }
+
+        if retryableHTTPStatusCodes.contains(nsError.code) {
+            let retryAfterSeconds = nsError.userInfo["RetryAfterSeconds"] as? TimeInterval
+            let reason = nsError.code == 429 ? "rate limited" : "temporary HTTP \(nsError.code)"
+            return ChatProviderRetryDecision(
+                reason: reason,
+                delaySeconds: backoffDelay(for: attempt, retryAfterSeconds: retryAfterSeconds)
+            )
+        }
+
+        if case ClaudeCodeCLIError.noResponseReceived = error {
+            return ChatProviderRetryDecision(
+                reason: "provider response parse failure",
+                delaySeconds: backoffDelay(for: attempt, retryAfterSeconds: nil)
+            )
+        }
+
+        return nil
+    }
+
+    private nonisolated static func backoffDelay(
+        for attempt: Int,
+        retryAfterSeconds: TimeInterval?
+    ) -> TimeInterval {
+        if let retryAfterSeconds, retryAfterSeconds > 0 {
+            return min(retryAfterSeconds, 8)
+        }
+
+        let base = pow(2.0, Double(max(0, attempt - 1))) * 0.75
+        return min(base, 6)
+    }
+}
+
+final class RetryingChatClient: AnthropicChatClient {
+    private let wrapped: any AnthropicChatClient
+    private let providerName: String
+
+    var model: String {
+        get { wrapped.model }
+        set { wrapped.model = newValue }
+    }
+
+    init(_ wrapped: any AnthropicChatClient, providerName: String) {
+        self.wrapped = wrapped
+        self.providerName = providerName
+    }
+
+    func analyzeImageStreaming(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String,
+        onTextChunk: @escaping @MainActor @Sendable (String) -> Void
+    ) async throws -> (text: String, duration: TimeInterval) {
+        let workflowStart = Date()
+        var attempt = 1
+        var lastError: Error?
+
+        while attempt <= ChatProviderRetryPolicy.maxAttempts {
+            do {
+                if attempt > 1 {
+                    FileLogger.log("🔁 \(providerName) retry attempt \(attempt)/\(ChatProviderRetryPolicy.maxAttempts)")
+                }
+
+                let result = try await wrapped.analyzeImageStreaming(
+                    images: images,
+                    systemPrompt: systemPrompt,
+                    conversationHistory: conversationHistory,
+                    userPrompt: userPrompt,
+                    onTextChunk: onTextChunk
+                )
+                return (text: result.text, duration: Date().timeIntervalSince(workflowStart))
+            } catch {
+                if error is CancellationError {
+                    throw error
+                }
+
+                lastError = error
+                guard let decision = ChatProviderRetryPolicy.decision(for: error, attempt: attempt) else {
+                    throw error
+                }
+
+                FileLogger.log(
+                    "⚠️ \(providerName) \(decision.reason); retrying in \(String(format: "%.1f", decision.delaySeconds))s"
+                )
+                try await Task.sleep(nanoseconds: UInt64(decision.delaySeconds * 1_000_000_000))
+                attempt += 1
+            }
+        }
+
+        throw lastError ?? ProviderPipelineError.emptyResponse(provider: providerName)
+    }
+}

--- a/leanring-buddy/ZAIChatClient.swift
+++ b/leanring-buddy/ZAIChatClient.swift
@@ -135,7 +135,7 @@ final class ZAIChatClient: AnthropicChatClient {
 
         let (byteStream, response) = try await session.bytes(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw ZAIChatClientError.invalidResponse
+            throw ProviderPipelineError.invalidResponse(provider: "Z.ai")
         }
 
         guard (200...299).contains(httpResponse.statusCode) else {
@@ -143,8 +143,10 @@ final class ZAIChatClient: AnthropicChatClient {
             for try await line in byteStream.lines {
                 errorLines.append(line)
             }
-            throw ZAIChatClientError.apiError(
+            throw ProviderPipelineError.apiError(
+                provider: "Z.ai",
                 statusCode: httpResponse.statusCode,
+                retryAfterSeconds: Self.retryAfterSeconds(from: httpResponse),
                 body: errorLines.joined(separator: "\n")
             )
         }
@@ -170,7 +172,7 @@ final class ZAIChatClient: AnthropicChatClient {
         }
 
         guard !accumulatedResponseText.isEmpty else {
-            throw ZAIChatClientError.emptyResponse
+            throw ProviderPipelineError.emptyResponse(provider: "Z.ai")
         }
 
         return (text: accumulatedResponseText, duration: Date().timeIntervalSince(startTime))
@@ -254,6 +256,25 @@ final class ZAIChatClient: AnthropicChatClient {
             return "image/png"
         }
         return "image/jpeg"
+    }
+
+    private static func retryAfterSeconds(from response: HTTPURLResponse) -> TimeInterval? {
+        guard let value = response.value(forHTTPHeaderField: "Retry-After")?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+
+        if let seconds = TimeInterval(value) {
+            return seconds
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss z"
+        guard let retryDate = formatter.date(from: value) else { return nil }
+        return max(0, retryDate.timeIntervalSinceNow)
     }
 
     private static func runtimeString(

--- a/leanring-buddyTests/leanring_buddyTests.swift
+++ b/leanring-buddyTests/leanring_buddyTests.swift
@@ -92,6 +92,43 @@ struct leanring_buddyTests {
         )
     }
 
+    @Test func retryPolicyRetriesRateLimitsTimeoutsAndParseFailures() async throws {
+        let rateLimitDecision = ChatProviderRetryPolicy.decision(
+            for: ProviderPipelineError.apiError(
+                provider: "Z.ai",
+                statusCode: 429,
+                retryAfterSeconds: 0.25,
+                body: "rate limited"
+            ),
+            attempt: 1
+        )
+        #expect(rateLimitDecision?.reason == "rate limited")
+        #expect(rateLimitDecision?.delaySeconds == 0.25)
+
+        let timeoutDecision = ChatProviderRetryPolicy.decision(
+            for: URLError(.timedOut),
+            attempt: 1
+        )
+        #expect(timeoutDecision?.reason == "network timeout/interruption")
+
+        let parseDecision = ChatProviderRetryPolicy.decision(
+            for: ProviderPipelineError.invalidResponse(provider: "Z.ai"),
+            attempt: 1
+        )
+        #expect(parseDecision?.reason == "provider response parse failure")
+
+        let authDecision = ChatProviderRetryPolicy.decision(
+            for: ProviderPipelineError.apiError(
+                provider: "Z.ai",
+                statusCode: 401,
+                retryAfterSeconds: nil,
+                body: "bad key"
+            ),
+            attempt: 1
+        )
+        #expect(authDecision == nil)
+    }
+
     @Test func localIntentCleansCutOffAppLaunchSpeech() async throws {
         let intent = LocalIntentRouter.route(transcript: "Can you open up Google for me and—")
 


### PR DESCRIPTION
## Summary
- Add a retry wrapper around the response provider call so transient failures retry without restarting the voice workflow
- Normalize provider errors for rate limits, temporary HTTP errors, empty/invalid streamed responses, and retry-after handling
- Wrap Z.ai, Claude proxy/OAuth, and Claude CLI fallback providers with the retry layer
- Add retry policy coverage and a short resilience doc

## Verification
- git diff --check
- xcrun swiftc -typecheck leanring-buddy/AnthropicChatClient.swift leanring-buddy/ClaudeCodeOAuthProvider.swift leanring-buddy/ClaudeCodeCLIClient.swift leanring-buddy/FileLogger.swift leanring-buddy/AppBundleConfiguration.swift leanring-buddy/ProviderPipelineError.swift leanring-buddy/RetryingChatClient.swift leanring-buddy/ZAIChatClient.swift leanring-buddy/ClaudeAPI.swift
- Local Swift smoke test confirmed a 429 retry succeeds on the second call without recreating the wrapper workflow