### PR TITLE
Prefer ElevenLabs for spoken replies

### DIFF
--- a/docs/elevenlabs-tts.md
+++ b/docs/elevenlabs-tts.md
@@ -1,0 +1,36 @@
+# ElevenLabs TTS
+
+ipop prefers ElevenLabs for spoken replies when an API key is configured. If no
+ElevenLabs key is present, it falls back to the built-in macOS `say` voice.
+
+## Enable Locally
+
+```sh
+defaults write com.yourcompany.leanring-buddy ClickyElevenLabsAPIKey '<your-elevenlabs-api-key>'
+```
+
+Optional voice/model overrides:
+
+```sh
+defaults write com.yourcompany.leanring-buddy ClickyElevenLabsVoiceID '21m00Tcm4TlvDq8ikWAM'
+defaults write com.yourcompany.leanring-buddy ClickyElevenLabsModelID 'eleven_flash_v2_5'
+```
+
+## Environment Overrides
+
+```sh
+CLICKY_ELEVENLABS_API_KEY='<your-elevenlabs-api-key>' \
+CLICKY_ELEVENLABS_VOICE_ID='21m00Tcm4TlvDq8ikWAM' \
+open /path/to/Clicky.app
+```
+
+Supported env vars:
+
+- `CLICKY_ELEVENLABS_API_KEY`
+- `CLICKY_ELEVENLABS_VOICE_ID`
+- `CLICKY_ELEVENLABS_MODEL_ID`
+
+## Fallback
+
+If ElevenLabs is missing, rate-limited, or returns an error, ipop logs the error
+and speaks the same text through the macOS voice fallback.

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -64,6 +64,7 @@ final class CompanionManager: ObservableObject {
     /// Process running `/usr/bin/say` for TTS fallback. Kept so we can
     /// terminate it when a new response starts before the old one finishes.
     private var macOSSpeechProcess: Process?
+    private var elevenLabsSpeechTask: Task<Void, Never>?
     private static let defaultMacOSVoiceName = "Samantha"
     private static let defaultMacOSVoiceRate = 178
 
@@ -614,6 +615,8 @@ final class CompanionManager: ObservableObject {
             // otherwise the old voice keeps droning until the next Claude
             // response arrives, which can briefly overlap with the new reply.
             currentResponseTask?.cancel()
+            elevenLabsSpeechTask?.cancel()
+            elevenLabsSpeechTask = nil
             elevenLabsTTSClient.stopPlayback()
             macOSSpeechProcess?.terminate()
             macOSSpeechProcess = nil
@@ -813,7 +816,7 @@ final class CompanionManager: ObservableObject {
         let acknowledgment = parallelTasks.count > 1
             ? "On it. Spawning \(parallelTasks.count) agents."
             : "On it."
-        speakWithMacOSVoice(acknowledgment)
+        speakWithPreferredVoice(acknowledgment)
         scheduleTransientHideIfNeeded()
 
         // Launch one sibling per task — they all run in parallel.
@@ -837,7 +840,7 @@ final class CompanionManager: ObservableObject {
                 let confirmation = isMultiTask
                     ? "Task \(taskIndex + 1) ready."
                     : "Done."
-                self.speakWithMacOSVoice(confirmation)
+                self.speakWithPreferredVoice(confirmation)
                 if !self.agentSessionManager.hasAnySessions {
                     self.agentSiblingsWindowManager.hide()
                     self.agentSessionDetailWindowManager.hide()
@@ -867,7 +870,7 @@ final class CompanionManager: ObservableObject {
             memoryManager.onTurnCompleted(userTranscript: transcript, assistantResponse: assistantResponse)
 
             if !spokenAcknowledgement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                speakWithMacOSVoice(spokenAcknowledgement)
+                speakWithPreferredVoice(spokenAcknowledgement)
                 voiceState = .responding
             } else {
                 voiceState = .idle
@@ -889,6 +892,8 @@ final class CompanionManager: ObservableObject {
     /// the buddy to fly to that element on screen.
     private func sendTranscriptToClaudeWithScreenshot(transcript: String) {
         currentResponseTask?.cancel()
+        elevenLabsSpeechTask?.cancel()
+        elevenLabsSpeechTask = nil
         elevenLabsTTSClient.stopPlayback()
         macOSSpeechProcess?.terminate()
         macOSSpeechProcess = nil
@@ -1060,12 +1065,10 @@ final class CompanionManager: ObservableObject {
 
                 ClickyAnalytics.trackAIResponseReceived(response: spokenText)
 
-                // Play the response via TTS using macOS say command.
-                // ElevenLabs requires a paid plan for API access, so we use
-                // the system say command which runs in a separate process and
-                // cannot conflict with AVAudioEngine used for mic capture.
+                // Prefer ElevenLabs when configured; fall back to macOS say so
+                // a missing key never blocks the interaction.
                 if !spokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    speakWithMacOSVoice(spokenText)
+                    speakWithPreferredVoice(spokenText)
                     voiceState = .responding
                 }
             } catch is CancellationError {
@@ -1117,7 +1120,7 @@ final class CompanionManager: ObservableObject {
     /// credits run out. Uses NSSpeechSynthesizer so it works even when
     /// ElevenLabs is down.
     private func speakCreditsErrorFallback() {
-        speakWithMacOSVoice("Sorry, something went wrong. Please try again.")
+        speakWithPreferredVoice("Sorry, something went wrong. Please try again.")
         voiceState = .responding
     }
 
@@ -1133,6 +1136,40 @@ final class CompanionManager: ObservableObject {
 
     /// Speaks text via `/usr/bin/say` in a separate process so it cannot
     /// conflict with the app's AVAudioEngine (used for microphone capture).
+    private func speakWithPreferredVoice(_ text: String) {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else { return }
+
+        macOSSpeechProcess?.terminate()
+        macOSSpeechProcess = nil
+        elevenLabsSpeechTask?.cancel()
+        elevenLabsSpeechTask = nil
+
+        guard elevenLabsTTSClient.isConfigured else {
+            FileLogger.log("🔊 ElevenLabs not configured — using macOS voice fallback")
+            speakWithMacOSVoice(trimmedText)
+            return
+        }
+
+        elevenLabsSpeechTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.elevenLabsTTSClient.speakText(trimmedText)
+                if !Task.isCancelled {
+                    self.elevenLabsSpeechTask = nil
+                }
+            } catch is CancellationError {
+                // User interrupted playback.
+            } catch {
+                guard !Task.isCancelled else { return }
+                ClickyAnalytics.trackTTSError(error: error.localizedDescription)
+                FileLogger.log("⚠️ ElevenLabs TTS failed: \(error.localizedDescription) — using macOS fallback")
+                self.speakWithMacOSVoice(trimmedText)
+                self.elevenLabsSpeechTask = nil
+            }
+        }
+    }
+
     private func speakWithMacOSVoice(_ text: String) {
         macOSSpeechProcess?.terminate()
         let process = Process()

--- a/leanring-buddy/ElevenLabsTTSClient.swift
+++ b/leanring-buddy/ElevenLabsTTSClient.swift
@@ -12,17 +12,25 @@ import Foundation
 
 @MainActor
 final class ElevenLabsTTSClient {
+    private static let defaultVoiceID = "21m00Tcm4TlvDq8ikWAM"
+    private static let defaultModelID = "eleven_flash_v2_5"
+
     private let ttsURL: URL
     private let apiKey: String
+    private let modelID: String
     private let session: URLSession
 
     /// The audio player for the current TTS playback. Kept alive so the
     /// audio finishes playing even if the caller doesn't hold a reference.
     private var audioPlayer: AVAudioPlayer?
 
-    init(apiKey: String = DirectAPICredentials.elevenLabsAPIKey,
-         voiceID: String = DirectAPICredentials.elevenLabsVoiceID) {
-        self.apiKey = apiKey
+    init(
+        apiKey: String = ElevenLabsTTSClient.configuredAPIKey(),
+        voiceID: String = ElevenLabsTTSClient.configuredVoiceID(),
+        modelID: String = ElevenLabsTTSClient.configuredModelID()
+    ) {
+        self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.modelID = modelID
         self.ttsURL = URL(string: "https://api.elevenlabs.io/v1/text-to-speech/\(voiceID)")!
 
         let configuration = URLSessionConfiguration.default
@@ -34,6 +42,14 @@ final class ElevenLabsTTSClient {
     /// Sends `text` to ElevenLabs TTS and plays the resulting audio.
     /// Throws on network or decoding errors. Cancellation-safe.
     func speakText(_ text: String) async throws {
+        guard isConfigured else {
+            throw NSError(
+                domain: "ElevenLabsTTS",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "ElevenLabs API key is not configured"]
+            )
+        }
+
         var request = URLRequest(url: ttsURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -42,10 +58,12 @@ final class ElevenLabsTTSClient {
 
         let body: [String: Any] = [
             "text": text,
-            "model_id": "eleven_flash_v2_5",
+            "model_id": modelID,
             "voice_settings": [
-                "stability": 0.5,
-                "similarity_boost": 0.75
+                "stability": 0.58,
+                "similarity_boost": 0.82,
+                "style": 0.18,
+                "use_speaker_boost": true
             ]
         ]
 
@@ -77,9 +95,71 @@ final class ElevenLabsTTSClient {
         audioPlayer?.isPlaying ?? false
     }
 
+    var isConfigured: Bool {
+        !apiKey.isEmpty
+    }
+
     /// Stops any in-progress playback immediately.
     func stopPlayback() {
         audioPlayer?.stop()
         audioPlayer = nil
+    }
+
+    private nonisolated static func configuredAPIKey() -> String {
+        runtimeString(
+            defaultsKeys: ["ClickyElevenLabsAPIKey", "ElevenLabsAPIKey"],
+            infoKeys: ["ClickyElevenLabsAPIKey", "ElevenLabsAPIKey"],
+            environmentKeys: ["CLICKY_ELEVENLABS_API_KEY", "ELEVENLABS_API_KEY"]
+        ) ?? DirectAPICredentials.elevenLabsAPIKey
+    }
+
+    private nonisolated static func configuredVoiceID() -> String {
+        runtimeString(
+            defaultsKeys: ["ClickyElevenLabsVoiceID", "ElevenLabsVoiceID"],
+            infoKeys: ["ClickyElevenLabsVoiceID", "ElevenLabsVoiceID"],
+            environmentKeys: ["CLICKY_ELEVENLABS_VOICE_ID", "ELEVENLABS_VOICE_ID"]
+        ) ?? {
+            let credentialVoiceID = DirectAPICredentials.elevenLabsVoiceID
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return credentialVoiceID.isEmpty ? defaultVoiceID : credentialVoiceID
+        }()
+    }
+
+    private nonisolated static func configuredModelID() -> String {
+        runtimeString(
+            defaultsKeys: ["ClickyElevenLabsModelID", "ElevenLabsModelID"],
+            infoKeys: ["ClickyElevenLabsModelID", "ElevenLabsModelID"],
+            environmentKeys: ["CLICKY_ELEVENLABS_MODEL_ID", "ELEVENLABS_MODEL_ID"]
+        ) ?? defaultModelID
+    }
+
+    private nonisolated static func runtimeString(
+        defaultsKeys: [String],
+        infoKeys: [String],
+        environmentKeys: [String]
+    ) -> String? {
+        for key in environmentKeys {
+            if let value = ProcessInfo.processInfo.environment[key]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !value.isEmpty {
+                return value
+            }
+        }
+
+        for key in defaultsKeys {
+            if let value = UserDefaults.standard.string(forKey: key)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !value.isEmpty {
+                return value
+            }
+        }
+
+        for key in infoKeys {
+            if let value = AppBundleConfiguration.stringValue(forKey: key) {
+                return value
+            }
+        }
+
+        return nil
     }
 }


### PR DESCRIPTION
## Summary
- Route spoken replies, acknowledgements, and task completions through ElevenLabs when configured
- Keep macOS say as fallback when ElevenLabs is missing or fails
- Allow ElevenLabs API key, voice ID, and model ID via defaults, Info.plist, or environment
- Cancel in-flight ElevenLabs requests/playback when the user starts a new push-to-talk turn
- Document local ElevenLabs setup

## Verification
- git diff --check
- xcrun swiftc -parse leanring-buddy/DirectAPICredentials.swift leanring-buddy/AppBundleConfiguration.swift leanring-buddy/ClickyAnalytics.swift leanring-buddy/ElevenLabsTTSClient.swift leanring-buddy/CompanionManager.swift