### PR TITLE
Publish release DMG to ipop-ai

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,11 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          repository: gagan114662/ipop-ai
           name: ipop.ai ${{ github.ref_name }}
           files: ${{ runner.temp }}/ipop-ai-beta.dmg
           generate_release_notes: true
+          make_latest: true
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.IPOP_AI_RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary\n- Point the tag release workflow at gagan114662/ipop-ai so the generated ipop-ai-beta.dmg lands at the URL used by ipop.ai\n- Require IPOP_AI_RELEASE_TOKEN for cross-repo release publishing\n- Keep unmatched-file failure and latest-release marking enabled\n\n## Verification\n- git diff --check\n- bash -n scripts/release.sh scripts/install-to-applications.sh\n