### PR TITLE
Wire Sparkle signing for ipop updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
           restore-keys: ${{ runner.os }}-spm-
 
       - name: Archive
-        env:
-          SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
         run: |
           set -o pipefail
           xcodebuild archive \
@@ -52,7 +50,6 @@ jobs:
             DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
             PRODUCT_BUNDLE_IDENTIFIER=ai.ipop.mac \
             PRODUCT_NAME="ipop.ai" \
-            SPARKLE_PUBLIC_ED_KEY="$SPARKLE_PUBLIC_ED_KEY" \
             | xcpretty
 
       - name: Export app
@@ -130,3 +127,31 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.IPOP_AI_RELEASE_TOKEN }}
+
+      - name: Generate Sparkle appcast
+        env:
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          set -euo pipefail
+          SPARKLE_BIN=$(find ~/Library/Developer/Xcode/DerivedData/leanring-buddy*/SourcePackages/artifacts/sparkle/Sparkle/bin -maxdepth 0 2>/dev/null | head -1)
+          mkdir -p "$RUNNER_TEMP/sparkle"
+          cp "$RUNNER_TEMP/ipop-ai-beta.dmg" "$RUNNER_TEMP/sparkle/ipop-ai-beta.dmg"
+          printf '%s' "$SPARKLE_PRIVATE_ED_KEY" | "$SPARKLE_BIN/generate_appcast" \
+            --ed-key-file - \
+            --download-url-prefix "https://github.com/gagan114662/ipop-ai/releases/download/${{ github.ref_name }}/" \
+            -o "$RUNNER_TEMP/appcast.xml" \
+            "$RUNNER_TEMP/sparkle"
+
+      - name: Publish Sparkle appcast
+        env:
+          GH_TOKEN: ${{ secrets.IPOP_AI_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          gh repo clone gagan114662/ipop-ai "$RUNNER_TEMP/ipop-ai-site"
+          cp "$RUNNER_TEMP/appcast.xml" "$RUNNER_TEMP/ipop-ai-site/appcast.xml"
+          cd "$RUNNER_TEMP/ipop-ai-site"
+          git add appcast.xml
+          git commit -m "Update appcast for ${{ github.ref_name }}" || exit 0
+          git push

--- a/leanring-buddy/Info.plist
+++ b/leanring-buddy/Info.plist
@@ -7,7 +7,7 @@
 	<key>SUFeedURL</key>
 	<string>https://ipop.ai/appcast.xml</string>
 	<key>SUPublicEDKey</key>
-	<string>$(SPARKLE_PUBLIC_ED_KEY)</string>
+	<string>MZwNd2qcdUyQyr5cacAaKuzRj7rKoh05/f2rxH8L4Lc=</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -45,8 +45,7 @@ DMG_BACKGROUND="${PROJECT_DIR}/dmg-background.png"
 
 GITHUB_REPO="gagan114662/ipop-ai"
 DMG_FILENAME="ipop-ai-beta.dmg"
-
-: "${SPARKLE_PUBLIC_ED_KEY:?Set SPARKLE_PUBLIC_ED_KEY to your Sparkle EdDSA public key before releasing.}"
+SPARKLE_ACCOUNT="${SPARKLE_ACCOUNT:-ipop.ai}"
 
 # Sparkle tools (auto-discovered from Xcode's SPM cache)
 SPARKLE_BIN=$(find ~/Library/Developer/Xcode/DerivedData/leanring-buddy*/SourcePackages/artifacts/sparkle/Sparkle/bin -maxdepth 0 2>/dev/null | head -1)
@@ -155,7 +154,6 @@ xcodebuild archive \
     CURRENT_PROJECT_VERSION="${BUILD_NUMBER}" \
     PRODUCT_BUNDLE_IDENTIFIER="ai.ipop.mac" \
     PRODUCT_NAME="${APP_NAME}" \
-    SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY}" \
     2>&1 | tail -5
 
 echo "✅ Archive created"
@@ -226,7 +224,7 @@ echo "✅ DMG notarized and stapled"
 # ── Step 6: Sign DMG with Sparkle EdDSA key ─────────────────────────────────
 
 echo "🔐 Signing DMG with Sparkle EdDSA key..."
-"${SPARKLE_BIN}/sign_update" "${DMG_PATH}"
+"${SPARKLE_BIN}/sign_update" --account "${SPARKLE_ACCOUNT}" "${DMG_PATH}"
 
 # ── Step 7: Generate / update appcast.xml ────────────────────────────────────
 # generate_appcast reads all DMGs in the releases/ directory, extracts version
@@ -236,6 +234,7 @@ echo "🔐 Signing DMG with Sparkle EdDSA key..."
 
 echo "📡 Generating appcast.xml..."
 "${SPARKLE_BIN}/generate_appcast" \
+    --account "${SPARKLE_ACCOUNT}" \
     --download-url-prefix "https://github.com/${GITHUB_REPO}/releases/download/${TAG}/" \
     -o "${PROJECT_DIR}/appcast.xml" \
     "${RELEASES_DIR}"


### PR DESCRIPTION
## Summary\n- Embed the generated ipop.ai Sparkle public EdDSA key in Info.plist\n- Configure local release script to use the ipop.ai Sparkle Keychain account\n- Generate and publish a signed Sparkle appcast from the release workflow using SPARKLE_PRIVATE_ED_KEY\n\n## Verification\n- git diff --check\n- plutil -lint leanring-buddy/Info.plist\n- bash -n scripts/release.sh scripts/install-to-applications.sh\n\n## Notes\n- SPARKLE_PRIVATE_ED_KEY and SPARKLE_PUBLIC_ED_KEY are set in gagan114662/clicky GitHub Secrets.\n- Apple Developer ID and notarization secrets are still required separately.\n